### PR TITLE
[WIP] Use Ray object store for shuffle exchange

### DIFF
--- a/raysql/__init__.py
+++ b/raysql/__init__.py
@@ -10,8 +10,9 @@ except ImportError:
 from ._raysql_internal import (
     Context,
     QueryStage,
+    ResultSet,
     serialize_execution_plan,
-    deserialize_execution_plan
+    deserialize_execution_plan,
 )
 
 __version__ = importlib_metadata.version(__name__)

--- a/raysql/context.py
+++ b/raysql/context.py
@@ -47,9 +47,12 @@ def execute_query_stage(query_stages, stage_id, workers, use_ray_shuffle):
     futures = []
     for part in range(concurrency):
         worker_index = part % len(workers)
+        opt = {}
+        if use_ray_shuffle:
+            opt["num_returns"] = output_partitions_count
         futures.append(
             workers[worker_index]
-            .execute_query_partition.options(num_returns=output_partitions_count)
+            .execute_query_partition.options(**opt)
             .remote(plan_bytes, part, *_get_worker_inputs(part, concurrency))
         )
 

--- a/raysql/context.py
+++ b/raysql/context.py
@@ -17,10 +17,10 @@ def execute_query_stage(query_stages, stage_id, workers, use_ray_shuffle):
     # if the query stage has a single output partition then we need to execute for the output
     # partition, otherwise we need to execute in parallel for each input partition
     concurrency = stage.get_input_partition_count()
-    if stage.get_output_partition_count() == 1:
+    output_partitions_count = stage.get_output_partition_count()
+    if output_partitions_count == 1:
         # reduce stage
         concurrency = 1
-    output_partitions_count = stage.get_output_partition_count()
 
     print(
         "Scheduling query stage #{} with {} input partitions and {} output partitions".format(
@@ -46,8 +46,6 @@ def execute_query_stage(query_stages, stage_id, workers, use_ray_shuffle):
     # round-robin allocation across workers
     futures = []
     for part in range(concurrency):
-        # TODO(@lsf) what happens if the number of output partitions is not equal
-        # to the concurrency here? Is that possible?
         worker_index = part % len(workers)
         futures.append(
             workers[worker_index]

--- a/raysql/context.py
+++ b/raysql/context.py
@@ -1,11 +1,22 @@
 import ray
-from raysql import Context, QueryStage, serialize_execution_plan
+
+from raysql import Context, QueryStage, ResultSet, serialize_execution_plan
+from raysql.worker import Worker
 
 
 @ray.remote
-def execute_query_stage(query_stages, stage_id, workers, use_ray_shuffle):
-    plan_bytes = query_stages[stage_id]
-    stage = QueryStage(stage_id, plan_bytes)
+def execute_query_stage(
+    query_stages: list[QueryStage],
+    stage_id: int,
+    workers: list[Worker],
+    use_ray_shuffle: bool,
+) -> tuple[int, list[ray.ObjectRef]]:
+    """
+    Execute a query stage on the workers.
+
+    Returns the stage ID, and a list of futures for the output partitions of the query stage.
+    """
+    stage = QueryStage(stage_id, query_stages[stage_id])
 
     # execute child stages first
     child_futures = []
@@ -13,12 +24,6 @@ def execute_query_stage(query_stages, stage_id, workers, use_ray_shuffle):
         child_futures.append(
             execute_query_stage.remote(query_stages, child_id, workers, use_ray_shuffle)
         )
-
-    # if we are using disk-based shuffle, wait until the child stages to finish
-    # writing the shuffle files to disk first.
-    if not use_ray_shuffle:
-        futures = ray.get(child_futures)
-        ray.get([f for lst in futures for f in lst])
 
     # if the query stage has a single output partition then we need to execute for the output
     # partition, otherwise we need to execute in parallel for each input partition
@@ -34,24 +39,35 @@ def execute_query_stage(query_stages, stage_id, workers, use_ray_shuffle):
         )
     )
 
-    plan_bytes = serialize_execution_plan(stage.get_execution_plan())
+    # Coordinate shuffle partitions
+    child_outputs = ray.get(child_futures)
 
-    # TODO(@lsf): deal with more than 1 child futures
-    inputs = child_futures[0] if len(child_futures) > 0 else []
-    inputs = ray.get(inputs)  # 2-D array of input_partitions * output_partitions
-    print("Stage #{}'s child inputs: {}".format(stage.id(), inputs))
-
-    def _get_worker_inputs(part, concurrency):
-        ret = []
+    def _get_worker_inputs(part: int) -> dict[int, list[ray.ObjectRef]]:
+        ret = {}
         if not use_ray_shuffle:
             return ret
+        return {c: get_child_inputs(part, lst) for c, lst in child_outputs}
+
+    def get_child_inputs(
+        part: int, inputs: list[list[ray.ObjectRef]]
+    ) -> list[ray.ObjectRef]:
+        ret = []
         for lst in inputs:
-            num_parts = len(lst)
-            parts_per_worker = num_parts // concurrency
-            ret.extend(lst[part * parts_per_worker : (part + 1) * parts_per_worker])
+            if isinstance(lst, list):
+                num_parts = len(lst)
+                parts_per_worker = num_parts // concurrency
+                ret.extend(lst[part * parts_per_worker : (part + 1) * parts_per_worker])
+            else:
+                ret.append(lst)
         return ret
 
+    # if we are using disk-based shuffle, wait until the child stages to finish
+    # writing the shuffle files to disk first.
+    if not use_ray_shuffle:
+        ray.get([f for lst in child_outputs for f in lst])
+
     # round-robin allocation across workers
+    plan_bytes = serialize_execution_plan(stage.get_execution_plan())
     futures = []
     for part in range(concurrency):
         worker_index = part % len(workers)
@@ -61,26 +77,26 @@ def execute_query_stage(query_stages, stage_id, workers, use_ray_shuffle):
         futures.append(
             workers[worker_index]
             .execute_query_partition.options(**opt)
-            .remote(plan_bytes, part, *_get_worker_inputs(part, concurrency))
+            .remote(plan_bytes, part, _get_worker_inputs(part))
         )
 
-    return futures
+    return stage_id, futures
 
 
 @ray.remote
 class RaySqlContext:
-    def __init__(self, workers, use_ray_shuffle):
+    def __init__(self, workers: list[Worker], use_ray_shuffle: bool):
         self.ctx = Context(len(workers), use_ray_shuffle)
         self.workers = workers
         self.use_ray_shuffle = use_ray_shuffle
 
-    def register_csv(self, table_name, path, has_header):
+    def register_csv(self, table_name: str, path: str, has_header: bool):
         self.ctx.register_csv(table_name, path, has_header)
 
-    def register_parquet(self, table_name, path):
+    def register_parquet(self, table_name: str, path: str):
         self.ctx.register_parquet(table_name, path)
 
-    def sql(self, sql):
+    def sql(self, sql: str) -> ResultSet:
         graph = self.ctx.plan(sql)
         final_stage_id = graph.get_final_query_stage().id()
 
@@ -94,6 +110,8 @@ class RaySqlContext:
         future = execute_query_stage.remote(
             query_stages, final_stage_id, self.workers, self.use_ray_shuffle
         )
-        stage_futures = ray.get(future)
-        # TODO(@lsf): we only support a single output partition for now
-        return ray.get(stage_futures[0])
+        _, partitions = ray.get(future)
+        # TODO(@lsf): we only support a single output partition for now?
+        result = ray.get(partitions[0])
+        # TODO(@lsf) is the following [0] necessary?
+        return ResultSet(result[0])

--- a/raysql/context.py
+++ b/raysql/context.py
@@ -64,7 +64,7 @@ def execute_query_stage(
     # if we are using disk-based shuffle, wait until the child stages to finish
     # writing the shuffle files to disk first.
     if not use_ray_shuffle:
-        ray.get([f for lst in child_outputs for f in lst])
+        ray.get([f for _, lst in child_outputs for f in lst])
 
     # round-robin allocation across workers
     plan_bytes = serialize_execution_plan(stage.get_execution_plan())
@@ -113,5 +113,4 @@ class RaySqlContext:
         _, partitions = ray.get(future)
         # TODO(@lsf): we only support a single output partition for now?
         result = ray.get(partitions[0])
-        # TODO(@lsf) is the following [0] necessary?
-        return ResultSet(result[0])
+        return result

--- a/raysql/context.py
+++ b/raysql/context.py
@@ -1,17 +1,23 @@
 import ray
-from raysql import Context, QueryStage, serialize_execution_plan
+from raysql import Context, QueryStage, ResultSet, serialize_execution_plan
 import time
+
 
 @ray.remote
 def execute_query_stage(query_stages, stage_id, workers):
-    plan_bytes = ray.get(query_stages[stage_id]).plan_bytes
+    plan_bytes = query_stages[stage_id]
     stage = QueryStage(stage_id, plan_bytes)
 
     # execute child stages first
     child_futures = []
     for child_id in stage.get_child_stage_ids():
-        child_futures.append(execute_query_stage.remote(query_stages, child_id, workers))
-    ray.get(child_futures)
+        child_futures.append(
+            execute_query_stage.remote(query_stages, child_id, workers)
+        )
+    child_results = ray.get(child_futures)
+    child_results = [ResultSet(r[0]) for r in child_results]
+    print(f"Query stage #{stage_id}: child results: {child_results}")
+    # TODO(@lsf): Need to pass the result set to this stage.
 
     # if the query stage has a single output partition then we need to execute for the output
     # partition, otherwise we need to execute in parallel for each input partition
@@ -20,31 +26,40 @@ def execute_query_stage(query_stages, stage_id, workers):
         # reduce stage
         concurrency = 1
 
-    print("Scheduling query stage #{} with {} input partitions and {} output partitions".format(stage.id(), stage.get_input_partition_count(), stage.get_output_partition_count()))
+    print(
+        "Scheduling query stage #{} with {} input partitions and {} output partitions".format(
+            stage.id(),
+            stage.get_input_partition_count(),
+            stage.get_output_partition_count(),
+        )
+    )
 
-    plan_bytes = ray.put(serialize_execution_plan(stage.get_execution_plan()))
+    plan_bytes = serialize_execution_plan(stage.get_execution_plan())
 
+    # TODO(@lsf): Need to pass child stage's shuffle output to each partition here.
     # round-robin allocation across workers
     futures = []
     for part in range(concurrency):
         worker_index = part % len(workers)
-        futures.append(workers[worker_index].execute_query_partition.remote(plan_bytes, part))
+        futures.append(
+            workers[worker_index].execute_query_partition.remote(plan_bytes, part)
+        )
 
     print("Waiting for query stage #{} to complete".format(stage.id()))
     start = time.time()
     result_set = ray.get(futures)
     end = time.time()
-    print("Query stage #{} completed in {} seconds".format(stage.id(), end-start))
+    print("Query stage #{} completed in {} seconds".format(stage.id(), end - start))
 
     return result_set
 
+
 @ray.remote
 class RaySqlContext:
-
-    def __init__(self, workers):
-        self.ctx = Context(len(workers))
+    def __init__(self, workers, use_ray_shuffle):
+        self.ctx = Context(len(workers), use_ray_shuffle)
         self.workers = workers
-        self.debug = False
+        self.use_ray_shuffle = use_ray_shuffle
 
     def register_csv(self, table_name, path, has_header):
         self.ctx.register_csv(table_name, path, has_header)
@@ -53,28 +68,15 @@ class RaySqlContext:
         self.ctx.register_parquet(table_name, path)
 
     def sql(self, sql):
-        if self.debug:
-            print(sql)
-
         graph = self.ctx.plan(sql)
         final_stage_id = graph.get_final_query_stage().id()
 
         # serialize the query stages and store in Ray object store
-        query_stages = []
-        for i in range(0, final_stage_id+1):
-            stage = graph.get_query_stage(i)
-            plan_bytes = serialize_execution_plan(stage.get_execution_plan())
-            query_stage_serde = QueryStageSerde(i, plan_bytes)
-            query_stages.append(ray.put(query_stage_serde))
+        query_stages = [
+            serialize_execution_plan(graph.get_query_stage(i).get_execution_plan())
+            for i in range(final_stage_id + 1)
+        ]
 
         # schedule execution
         future = execute_query_stage.remote(query_stages, final_stage_id, self.workers)
         return ray.get(future)
-
-class QueryStageSerde:
-    def __init__(self, id, plan_bytes):
-        self.id = id
-        self.plan_bytes = plan_bytes
-
-    def __reduce__(self):
-        return (self.__class__, (self.id, self.plan_bytes))

--- a/raysql/context.py
+++ b/raysql/context.py
@@ -37,6 +37,8 @@ def execute_query_stage(query_stages, stage_id, workers, use_ray_shuffle):
 
     def _get_worker_inputs(part, concurrency):
         ret = []
+        if not use_ray_shuffle:
+            return ret
         for lst in inputs:
             num_parts = len(lst)
             parts_per_worker = num_parts // concurrency

--- a/raysql/main.py
+++ b/raysql/main.py
@@ -1,6 +1,7 @@
 import os
 
 import ray
+from raysql import ResultSet
 from raysql.context import RaySqlContext
 from raysql.worker import Worker
 
@@ -43,9 +44,9 @@ def tpchq(ctx: RaySqlContext, q: int = 14):
     sql = load_query(q)
     result_set = ray.get(ctx.sql.remote(sql))
     print("Result:")
-    print(result_set)
+    print(ResultSet(result_set))
 
 
-use_ray_shuffle = True
+use_ray_shuffle = False
 ctx = setup_context(use_ray_shuffle)
 tpchq(ctx)

--- a/raysql/main.py
+++ b/raysql/main.py
@@ -1,7 +1,6 @@
 import os
 
 import ray
-from raysql import ResultSet
 from raysql.context import RaySqlContext
 from raysql.worker import Worker
 
@@ -40,12 +39,11 @@ def load_query(n: int) -> str:
         return fin.read()
 
 
-def tpchq(ctx: RaySqlContext, q: int = 1):
+def tpchq(ctx: RaySqlContext, q: int = 14):
     sql = load_query(q)
     result_set = ray.get(ctx.sql.remote(sql))
     print("Result:")
     print(result_set)
-    print(ResultSet(result_set[0]))
 
 
 use_ray_shuffle = True

--- a/raysql/main.py
+++ b/raysql/main.py
@@ -8,7 +8,7 @@ from raysql.worker import Worker
 DATA_DIR = "/home/ubuntu/tpch/sf1-parquet"
 # DATA_DIR = "/home/ubuntu/sf10-parquet"
 
-ray.init()
+ray.init(local_mode=True)
 
 
 def setup_context(use_ray_shuffle: bool) -> RaySqlContext:
@@ -44,7 +44,7 @@ def tpchq(ctx: RaySqlContext, q: int = 1):
     result_set = ray.get(ctx.sql.remote(sql))
     print("Result:")
     print(result_set)
-    print(ResultSet(result_set))
+    print(ResultSet(result_set[0]))
 
 
 use_ray_shuffle = True

--- a/raysql/main.py
+++ b/raysql/main.py
@@ -1,0 +1,49 @@
+import os
+
+import ray
+from raysql.context import RaySqlContext
+from raysql.worker import Worker
+
+DATA_DIR = "/home/ubuntu/tpch/sf1-parquet"
+# DATA_DIR = "/home/ubuntu/sf10-parquet"
+
+ray.init()
+
+
+def setup_context(use_ray_shuffle: bool) -> RaySqlContext:
+    num_workers = 2
+    # num_workers = os.cpu_count()
+    workers = [Worker.remote() for _ in range(num_workers)]
+    ctx = RaySqlContext.remote(workers, use_ray_shuffle)
+    register_tasks = []
+    register_tasks.append(ctx.register_csv.remote("tips", "examples/tips.csv", True))
+    for table in [
+        "customer",
+        "lineitem",
+        "nation",
+        "orders",
+        "part",
+        "partsupp",
+        "region",
+        "supplier",
+    ]:
+        register_tasks.append(
+            ctx.register_parquet.remote(table, f"{DATA_DIR}/{table}.parquet")
+        )
+    return ctx
+
+
+def load_query(n: int) -> str:
+    with open(f"testdata/queries/q{n}.sql") as fin:
+        return fin.read()
+
+
+def tpchq(ctx: RaySqlContext, q: int = 1):
+    sql = load_query(q)
+    result_set = ray.get(ctx.sql.remote(sql))
+    print(result_set[0])
+
+
+use_ray_shuffle = True
+ctx = setup_context(use_ray_shuffle)
+tpchq(ctx)

--- a/raysql/main.py
+++ b/raysql/main.py
@@ -1,6 +1,7 @@
 import os
 
 import ray
+from raysql import ResultSet
 from raysql.context import RaySqlContext
 from raysql.worker import Worker
 
@@ -41,7 +42,9 @@ def load_query(n: int) -> str:
 def tpchq(ctx: RaySqlContext, q: int = 1):
     sql = load_query(q)
     result_set = ray.get(ctx.sql.remote(sql))
-    print(result_set[0])
+    print("Result:")
+    print(result_set)
+    print(ResultSet(result_set))
 
 
 use_ray_shuffle = True

--- a/raysql/main.py
+++ b/raysql/main.py
@@ -8,7 +8,8 @@ from raysql.worker import Worker
 DATA_DIR = "/home/ubuntu/tpch/sf1-parquet"
 # DATA_DIR = "/home/ubuntu/sf10-parquet"
 
-ray.init(local_mode=True)
+ray.init()
+# ray.init(local_mode=True)
 
 
 def setup_context(use_ray_shuffle: bool) -> RaySqlContext:

--- a/raysql/tests/test_context.py
+++ b/raysql/tests/test_context.py
@@ -2,6 +2,6 @@ import pytest
 from raysql import Context
 
 def test():
-    ctx = Context()
+    ctx = Context(1, False)
     ctx.register_csv('tips', 'examples/tips.csv', True)
     ctx.plan("SELECT * FROM tips")

--- a/raysql/worker.py
+++ b/raysql/worker.py
@@ -1,11 +1,12 @@
 import ray
 from raysql import Context, deserialize_execution_plan
 
+
 @ray.remote
 class Worker:
     def __init__(self):
-        self.ctx = Context(1)
-        self.debug = False
+        self.ctx = Context(1, False)
+        self.debug = True
 
     def execute_query_partition(self, plan_bytes, part):
         plan = deserialize_execution_plan(plan_bytes)
@@ -18,5 +19,4 @@ class Worker:
         # (perhaps via Substrait, once DataFusion supports converting a physical plan to Substrait)
         results = self.ctx.execute_partition(plan, part)
 
-        # TODO: return results here instead of string representation of results
-        return "{}".format(results)
+        return results.tobytes()

--- a/raysql/worker.py
+++ b/raysql/worker.py
@@ -35,4 +35,5 @@ class Worker:
         # (perhaps via Substrait, once DataFusion supports converting a physical plan to Substrait)
         result_set = self.ctx.execute_partition(plan, part, input_partitions_map)
 
-        return result_set.tobyteslist()
+        ret = result_set.tobyteslist()
+        return ret[0] if len(ret) == 1 else ret

--- a/raysql/worker.py
+++ b/raysql/worker.py
@@ -13,8 +13,8 @@ class Worker:
 
         if self.debug:
             print(
-                "Executing partition #{} with {} shuffle inputs:\n{}".format(
-                    part, len(inputs), plan.display_indent()
+                "Worker executing plan {} partition #{} with {} shuffle inputs:\n{}".format(
+                    plan.display(), part, len(inputs), plan.display_indent()
                 )
             )
 

--- a/raysql/worker.py
+++ b/raysql/worker.py
@@ -8,16 +8,19 @@ class Worker:
         self.ctx = Context(1, False)
         self.debug = True
 
-    def execute_query_partition(self, plan_bytes, part, inputs):
+    def execute_query_partition(self, plan_bytes, part, *inputs):
         plan = deserialize_execution_plan(plan_bytes)
-        inputs = inputs[part : part + 1]
 
         if self.debug:
-            print("Executing partition #{}:\n{}".format(part, plan.display_indent()))
+            print(
+                "Executing partition #{} with {} shuffle inputs:\n{}".format(
+                    part, len(inputs), plan.display_indent()
+                )
+            )
 
         # This is delegating to DataFusion for execution, but this would be a good place
         # to plug in other execution engines by translating the plan into another engine's plan
         # (perhaps via Substrait, once DataFusion supports converting a physical plan to Substrait)
-        results = self.ctx.execute_partition(plan, part, inputs)
+        result_set = self.ctx.execute_partition(plan, part, inputs)
 
-        return results.tobytes()
+        return result_set.tobyteslist()

--- a/raysql/worker.py
+++ b/raysql/worker.py
@@ -1,4 +1,5 @@
 import ray
+
 from raysql import Context, deserialize_execution_plan
 
 
@@ -8,19 +9,30 @@ class Worker:
         self.ctx = Context(1, False)
         self.debug = True
 
-    def execute_query_partition(self, plan_bytes, part, *inputs):
+    def execute_query_partition(
+        self,
+        plan_bytes: bytes,
+        part: int,
+        input_partitions_map: dict[int, list[ray.ObjectRef]],
+    ) -> list[bytes]:
         plan = deserialize_execution_plan(plan_bytes)
 
         if self.debug:
             print(
                 "Worker executing plan {} partition #{} with {} shuffle inputs:\n{}".format(
-                    plan.display(), part, len(inputs), plan.display_indent()
+                    plan.display(),
+                    part,
+                    {i: len(parts) for i, parts in input_partitions_map.items()},
+                    plan.display_indent(),
                 )
             )
 
+        input_partitions_map = {
+            i: ray.get(parts) for i, parts in input_partitions_map.items()
+        }
         # This is delegating to DataFusion for execution, but this would be a good place
         # to plug in other execution engines by translating the plan into another engine's plan
         # (perhaps via Substrait, once DataFusion supports converting a physical plan to Substrait)
-        result_set = self.ctx.execute_partition(plan, part, inputs)
+        result_set = self.ctx.execute_partition(plan, part, input_partitions_map)
 
         return result_set.tobyteslist()

--- a/raysql/worker.py
+++ b/raysql/worker.py
@@ -8,8 +8,9 @@ class Worker:
         self.ctx = Context(1, False)
         self.debug = True
 
-    def execute_query_partition(self, plan_bytes, part):
+    def execute_query_partition(self, plan_bytes, part, inputs):
         plan = deserialize_execution_plan(plan_bytes)
+        inputs = inputs[part : part + 1]
 
         if self.debug:
             print("Executing partition #{}:\n{}".format(part, plan.display_indent()))
@@ -17,6 +18,6 @@ class Worker:
         # This is delegating to DataFusion for execution, but this would be a good place
         # to plug in other execution engines by translating the plan into another engine's plan
         # (perhaps via Substrait, once DataFusion supports converting a physical plan to Substrait)
-        results = self.ctx.execute_partition(plan, part)
+        results = self.ctx.execute_partition(plan, part, inputs)
 
         return results.tobytes()

--- a/src/context.rs
+++ b/src/context.rs
@@ -98,8 +98,7 @@ impl PyContext {
         part: usize,
         inputs: PyObject,
     ) -> PyResultSet {
-        let planstr = plan.display();
-        let batches: Vec<_> = self
+        let batches = self
             ._execute_partition(plan, part, inputs)
             .unwrap()
             .iter()
@@ -136,7 +135,7 @@ fn _set_inputs_for_ray_shuffle_reader(
         let input_objects = inputs
             .as_ref(py)
             .iter()
-            .expect("expected iterator")
+            .expect("expected iterable")
             .map(|input| {
                 input
                     .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod utils;
 fn _raysql_internal(_py: Python, m: &PyModule) -> PyResult<()> {
     // register classes that can be created directly from Python code
     m.add_class::<context::PyContext>()?;
+    m.add_class::<context::PyResultSet>()?;
     m.add_class::<query_stage::PyQueryStage>()?;
     m.add_function(wrap_pyfunction!(serialize_execution_plan, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize_execution_plan, m)?)?;

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -1,5 +1,6 @@
 use crate::query_stage::PyQueryStage;
 use crate::query_stage::QueryStage;
+use crate::shuffle::{RayShuffleReaderExec, RayShuffleWriterExec};
 use crate::shuffle::{ShuffleReaderExec, ShuffleWriterExec};
 use datafusion::error::Result;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
@@ -96,9 +97,12 @@ impl ExecutionGraph {
     }
 }
 
-pub fn make_execution_graph(plan: Arc<dyn ExecutionPlan>) -> Result<ExecutionGraph> {
+pub fn make_execution_graph(
+    plan: Arc<dyn ExecutionPlan>,
+    use_ray_shuffle: bool,
+) -> Result<ExecutionGraph> {
     let mut graph = ExecutionGraph::new();
-    let root = generate_query_stages(plan, &mut graph)?;
+    let root = generate_query_stages(plan, &mut graph, use_ray_shuffle)?;
     graph.add_query_stage(graph.next_id(), root);
     Ok(graph)
 }
@@ -108,12 +112,13 @@ pub fn make_execution_graph(plan: Arc<dyn ExecutionPlan>) -> Result<ExecutionGra
 fn generate_query_stages(
     plan: Arc<dyn ExecutionPlan>,
     graph: &mut ExecutionGraph,
+    use_ray_shuffle: bool,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     // recurse down first
     let new_children: Vec<Arc<dyn ExecutionPlan>> = plan
         .children()
         .iter()
-        .map(|x| generate_query_stages(x.clone(), graph))
+        .map(|x| generate_query_stages(x.clone(), graph, use_ray_shuffle))
         .collect::<Result<Vec<_>>>()?;
     let plan = with_new_children_if_necessary(plan, new_children)?;
 
@@ -130,6 +135,7 @@ fn generate_query_stages(
                 plan.children()[0].clone(),
                 graph,
                 partitioning_scheme.clone(),
+                use_ray_shuffle,
             ),
         }
     } else if plan
@@ -139,7 +145,8 @@ fn generate_query_stages(
     {
         let coalesce_input = plan.children()[0].clone();
         let partitioning_scheme = coalesce_input.output_partitioning();
-        let new_input = create_shuffle_exchange(coalesce_input, graph, partitioning_scheme)?;
+        let new_input =
+            create_shuffle_exchange(coalesce_input, graph, partitioning_scheme, use_ray_shuffle)?;
         with_new_children_if_necessary(plan, vec![new_input])
     } else if plan
         .as_any()
@@ -148,7 +155,12 @@ fn generate_query_stages(
     {
         let partitioned_sort_plan = plan.children()[0].clone();
         let partitioning_scheme = partitioned_sort_plan.output_partitioning();
-        let new_input = create_shuffle_exchange(partitioned_sort_plan, graph, partitioning_scheme)?;
+        let new_input = create_shuffle_exchange(
+            partitioned_sort_plan,
+            graph,
+            partitioning_scheme,
+            use_ray_shuffle,
+        )?;
         with_new_children_if_necessary(plan, vec![new_input])
     } else {
         Ok(plan)
@@ -171,6 +183,7 @@ fn create_shuffle_exchange(
     plan: Arc<dyn ExecutionPlan>,
     graph: &mut ExecutionGraph,
     partitioning_scheme: Partitioning,
+    use_ray_shuffle: bool,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     // introduce shuffle to produce one output partition
     let stage_id = graph.next_id();
@@ -179,26 +192,44 @@ fn create_shuffle_exchange(
     let temp_dir = create_temp_dir(stage_id)?;
 
     let shuffle_writer_input = plan.clone();
-    let shuffle_writer = ShuffleWriterExec::new(
-        stage_id,
-        shuffle_writer_input,
-        partitioning_scheme.clone(),
-        &temp_dir,
-    );
+    let shuffle_writer: Arc<dyn ExecutionPlan> = if use_ray_shuffle {
+        Arc::new(RayShuffleWriterExec::new(
+            stage_id,
+            shuffle_writer_input,
+            partitioning_scheme.clone(),
+            &temp_dir,
+        ))
+    } else {
+        Arc::new(ShuffleWriterExec::new(
+            stage_id,
+            shuffle_writer_input,
+            partitioning_scheme.clone(),
+            &temp_dir,
+        ))
+    };
 
     debug!(
         "Created shuffle writer with output partitioning {:?}",
         shuffle_writer.output_partitioning()
     );
 
-    let stage_id = graph.add_query_stage(stage_id, Arc::new(shuffle_writer));
+    let stage_id = graph.add_query_stage(stage_id, shuffle_writer);
     // replace the plan with a shuffle reader
-    Ok(Arc::new(ShuffleReaderExec::new(
-        stage_id,
-        plan.schema(),
-        partitioning_scheme,
-        &temp_dir,
-    )))
+    if use_ray_shuffle {
+        Ok(Arc::new(RayShuffleReaderExec::new(
+            stage_id,
+            plan.schema(),
+            partitioning_scheme,
+            &temp_dir,
+        )))
+    } else {
+        Ok(Arc::new(ShuffleReaderExec::new(
+            stage_id,
+            plan.schema(),
+            partitioning_scheme,
+            &temp_dir,
+        )))
+    }
 }
 
 fn create_temp_dir(stage_id: usize) -> Result<String> {

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -197,7 +197,6 @@ fn create_shuffle_exchange(
             stage_id,
             shuffle_writer_input,
             partitioning_scheme.clone(),
-            &temp_dir,
         ))
     } else {
         Arc::new(ShuffleWriterExec::new(
@@ -220,7 +219,6 @@ fn create_shuffle_exchange(
             stage_id,
             plan.schema(),
             partitioning_scheme,
-            &temp_dir,
         )))
     } else {
         Ok(Arc::new(ShuffleReaderExec::new(
@@ -396,7 +394,7 @@ mod test {
         ));
 
         output.push_str("RaySQL Plan\n===========\n\n");
-        let graph = make_execution_graph(plan)?;
+        let graph = make_execution_graph(plan, false)?;
         for id in 0..=graph.get_final_query_stage().id {
             let query_stage = graph.query_stages.get(&id).unwrap();
             output.push_str(&format!(

--- a/src/proto/generated/protobuf.rs
+++ b/src/proto/generated/protobuf.rs
@@ -69,9 +69,6 @@ pub struct RayShuffleReaderExecNode {
     pub partitioning: ::core::option::Option<
         ::datafusion_proto::protobuf::PhysicalHashRepartition,
     >,
-    /// directory for shuffle files
-    #[prost(string, tag = "4")]
-    pub shuffle_dir: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -87,7 +84,4 @@ pub struct RayShuffleWriterExecNode {
     pub partitioning: ::core::option::Option<
         ::datafusion_proto::protobuf::PhysicalHashRepartition,
     >,
-    /// directory for shuffle files
-    #[prost(string, tag = "4")]
-    pub shuffle_dir: ::prost::alloc::string::String,
 }

--- a/src/proto/generated/protobuf.rs
+++ b/src/proto/generated/protobuf.rs
@@ -1,7 +1,7 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RaySqlExecNode {
-    #[prost(oneof = "ray_sql_exec_node::PlanType", tags = "1, 2")]
+    #[prost(oneof = "ray_sql_exec_node::PlanType", tags = "1, 2, 3, 4")]
     pub plan_type: ::core::option::Option<ray_sql_exec_node::PlanType>,
 }
 /// Nested message and enum types in `RaySqlExecNode`.
@@ -13,6 +13,10 @@ pub mod ray_sql_exec_node {
         ShuffleReader(super::ShuffleReaderExecNode),
         #[prost(message, tag = "2")]
         ShuffleWriter(super::ShuffleWriterExecNode),
+        #[prost(message, tag = "3")]
+        RayShuffleReader(super::RayShuffleReaderExecNode),
+        #[prost(message, tag = "4")]
+        RayShuffleWriter(super::RayShuffleWriterExecNode),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -36,6 +40,42 @@ pub struct ShuffleReaderExecNode {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ShuffleWriterExecNode {
+    /// stage that is writing the shuffle files
+    #[prost(uint32, tag = "1")]
+    pub stage_id: u32,
+    /// plan to execute
+    #[prost(message, optional, tag = "2")]
+    pub plan: ::core::option::Option<::datafusion_proto::protobuf::PhysicalPlanNode>,
+    /// output partitioning schema
+    #[prost(message, optional, tag = "3")]
+    pub partitioning: ::core::option::Option<
+        ::datafusion_proto::protobuf::PhysicalHashRepartition,
+    >,
+    /// directory for shuffle files
+    #[prost(string, tag = "4")]
+    pub shuffle_dir: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RayShuffleReaderExecNode {
+    /// stage to read from
+    #[prost(uint32, tag = "1")]
+    pub stage_id: u32,
+    /// schema of the shuffle stage
+    #[prost(message, optional, tag = "2")]
+    pub schema: ::core::option::Option<::datafusion_proto::protobuf::Schema>,
+    /// this must match the output partitioning of the writer we are reading from
+    #[prost(message, optional, tag = "3")]
+    pub partitioning: ::core::option::Option<
+        ::datafusion_proto::protobuf::PhysicalHashRepartition,
+    >,
+    /// directory for shuffle files
+    #[prost(string, tag = "4")]
+    pub shuffle_dir: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RayShuffleWriterExecNode {
     /// stage that is writing the shuffle files
     #[prost(uint32, tag = "1")]
     pub stage_id: u32,

--- a/src/proto/raysql.proto
+++ b/src/proto/raysql.proto
@@ -46,8 +46,6 @@ message RayShuffleReaderExecNode {
   datafusion.Schema schema = 2;
   // this must match the output partitioning of the writer we are reading from
   datafusion.PhysicalHashRepartition partitioning = 3;
-  // directory for shuffle files
-  string shuffle_dir = 4;
 }
 
 message RayShuffleWriterExecNode {
@@ -57,6 +55,4 @@ message RayShuffleWriterExecNode {
   datafusion.PhysicalPlanNode plan = 2;
   // output partitioning schema
   datafusion.PhysicalHashRepartition partitioning = 3;
-  // directory for shuffle files
-  string shuffle_dir = 4;
 }

--- a/src/proto/raysql.proto
+++ b/src/proto/raysql.proto
@@ -12,6 +12,8 @@ message RaySqlExecNode {
   oneof PlanType {
     ShuffleReaderExecNode shuffle_reader = 1;
     ShuffleWriterExecNode shuffle_writer = 2;
+    RayShuffleReaderExecNode ray_shuffle_reader = 3;
+    RayShuffleWriterExecNode ray_shuffle_writer = 4;
   }
 }
 
@@ -27,6 +29,28 @@ message ShuffleReaderExecNode {
 }
 
 message ShuffleWriterExecNode {
+  // stage that is writing the shuffle files
+  uint32 stage_id = 1;
+  // plan to execute
+  datafusion.PhysicalPlanNode plan = 2;
+  // output partitioning schema
+  datafusion.PhysicalHashRepartition partitioning = 3;
+  // directory for shuffle files
+  string shuffle_dir = 4;
+}
+
+message RayShuffleReaderExecNode {
+  // stage to read from
+  uint32 stage_id = 1;
+  // schema of the shuffle stage
+  datafusion.Schema schema = 2;
+  // this must match the output partitioning of the writer we are reading from
+  datafusion.PhysicalHashRepartition partitioning = 3;
+  // directory for shuffle files
+  string shuffle_dir = 4;
+}
+
+message RayShuffleWriterExecNode {
   // stage that is writing the shuffle files
   uint32 stage_id = 1;
   // plan to execute

--- a/src/query_stage.rs
+++ b/src/query_stage.rs
@@ -1,6 +1,6 @@
 use crate::shuffle::{RayShuffleReaderExec, ShuffleCodec, ShuffleReaderExec};
 use datafusion::error::Result;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::{ExecutionPlan, Partitioning};
 use datafusion::prelude::SessionContext;
 use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
 use datafusion_python::physical_plan::PyExecutionPlan;
@@ -47,7 +47,13 @@ impl PyQueryStage {
     }
 
     pub fn get_output_partition_count(&self) -> usize {
-        self.stage.plan.output_partitioning().partition_count()
+        match self.stage.plan.output_partitioning() {
+            Partitioning::UnknownPartitioning(_) => {
+                println!("UnknownPartitioning returning 1");
+                1
+            }
+            p => p.partition_count(),
+        }
     }
 }
 
@@ -77,7 +83,14 @@ impl QueryStage {
     }
 
     pub fn get_output_partition_count(&self) -> usize {
-        self.plan.output_partitioning().partition_count()
+        // TODO(@lsf) UnknownPartitioning should return 1?
+        match self.plan.output_partitioning() {
+            Partitioning::UnknownPartitioning(_) => {
+                println!("UnknownPartitioning returning 1");
+                1
+            }
+            p => p.partition_count(),
+        }
     }
 }
 

--- a/src/shuffle/codec.rs
+++ b/src/shuffle/codec.rs
@@ -80,7 +80,6 @@ impl PhysicalExtensionCodec for ShuffleCodec {
                     reader.stage_id as usize,
                     schema,
                     hash_part.unwrap(),
-                    &reader.shuffle_dir,
                 )))
             }
             Some(PlanType::RayShuffleWriter(writer)) => {
@@ -98,7 +97,6 @@ impl PhysicalExtensionCodec for ShuffleCodec {
                     writer.stage_id as usize,
                     plan,
                     hash_part.unwrap(),
-                    &writer.shuffle_dir,
                 )))
             }
             _ => unreachable!(),
@@ -137,7 +135,6 @@ impl PhysicalExtensionCodec for ShuffleCodec {
                 stage_id: reader.stage_id as u32,
                 schema: Some(schema),
                 partitioning: Some(partitioning),
-                shuffle_dir: reader.shuffle_dir.clone(),
             };
             PlanType::RayShuffleReader(reader)
         } else if let Some(writer) = node.as_any().downcast_ref::<RayShuffleWriterExec>() {
@@ -147,7 +144,6 @@ impl PhysicalExtensionCodec for ShuffleCodec {
                 stage_id: writer.stage_id as u32,
                 plan: Some(plan),
                 partitioning: Some(partitioning),
-                shuffle_dir: writer.shuffle_dir.clone(),
             };
             PlanType::RayShuffleWriter(writer)
         } else {

--- a/src/shuffle/codec.rs
+++ b/src/shuffle/codec.rs
@@ -1,6 +1,11 @@
 use crate::protobuf::ray_sql_exec_node::PlanType;
-use crate::protobuf::{RaySqlExecNode, ShuffleReaderExecNode, ShuffleWriterExecNode};
-use crate::shuffle::{ShuffleReaderExec, ShuffleWriterExec};
+use crate::protobuf::{
+    RayShuffleReaderExecNode, RayShuffleWriterExecNode, RaySqlExecNode, ShuffleReaderExecNode,
+    ShuffleWriterExecNode,
+};
+use crate::shuffle::{
+    RayShuffleReaderExec, RayShuffleWriterExec, ShuffleReaderExec, ShuffleWriterExec,
+};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::runtime_env::RuntimeEnv;
@@ -63,6 +68,39 @@ impl PhysicalExtensionCodec for ShuffleCodec {
                     &writer.shuffle_dir,
                 )))
             }
+            Some(PlanType::RayShuffleReader(reader)) => {
+                let schema = reader.schema.as_ref().unwrap();
+                let schema: SchemaRef = Arc::new(schema.try_into().unwrap());
+                let hash_part = parse_protobuf_hash_partitioning(
+                    reader.partitioning.as_ref(),
+                    registry,
+                    &schema,
+                )?;
+                Ok(Arc::new(RayShuffleReaderExec::new(
+                    reader.stage_id as usize,
+                    schema,
+                    hash_part.unwrap(),
+                    &reader.shuffle_dir,
+                )))
+            }
+            Some(PlanType::RayShuffleWriter(writer)) => {
+                let plan = writer.plan.unwrap().try_into_physical_plan(
+                    registry,
+                    &RuntimeEnv::default(),
+                    self,
+                )?;
+                let hash_part = parse_protobuf_hash_partitioning(
+                    writer.partitioning.as_ref(),
+                    registry,
+                    plan.schema().as_ref(),
+                )?;
+                Ok(Arc::new(RayShuffleWriterExec::new(
+                    writer.stage_id as usize,
+                    plan,
+                    hash_part.unwrap(),
+                    &writer.shuffle_dir,
+                )))
+            }
             _ => unreachable!(),
         }
     }
@@ -92,6 +130,26 @@ impl PhysicalExtensionCodec for ShuffleCodec {
                 shuffle_dir: writer.shuffle_dir.clone(),
             };
             PlanType::ShuffleWriter(writer)
+        } else if let Some(reader) = node.as_any().downcast_ref::<RayShuffleReaderExec>() {
+            let schema: protobuf::Schema = reader.schema().try_into().unwrap();
+            let partitioning = encode_partitioning_scheme(&reader.output_partitioning())?;
+            let reader = RayShuffleReaderExecNode {
+                stage_id: reader.stage_id as u32,
+                schema: Some(schema),
+                partitioning: Some(partitioning),
+                shuffle_dir: reader.shuffle_dir.clone(),
+            };
+            PlanType::RayShuffleReader(reader)
+        } else if let Some(writer) = node.as_any().downcast_ref::<RayShuffleWriterExec>() {
+            let plan = PhysicalPlanNode::try_from_physical_plan(writer.plan.clone(), self)?;
+            let partitioning = encode_partitioning_scheme(&writer.output_partitioning())?;
+            let writer = RayShuffleWriterExecNode {
+                stage_id: writer.stage_id as u32,
+                plan: Some(plan),
+                partitioning: Some(partitioning),
+                shuffle_dir: writer.shuffle_dir.clone(),
+            };
+            PlanType::RayShuffleWriter(writer)
         } else {
             unreachable!()
         };

--- a/src/shuffle/mod.rs
+++ b/src/shuffle/mod.rs
@@ -1,7 +1,10 @@
 mod codec;
+mod ray_shuffle;
 mod reader;
 mod writer;
 
 pub use codec::ShuffleCodec;
+pub use ray_shuffle::RayShuffleReaderExec;
+pub use ray_shuffle::RayShuffleWriterExec;
 pub use reader::ShuffleReaderExec;
 pub use writer::ShuffleWriterExec;

--- a/src/shuffle/ray_shuffle/mod.rs
+++ b/src/shuffle/ray_shuffle/mod.rs
@@ -1,0 +1,5 @@
+mod reader;
+mod writer;
+
+pub use reader::RayShuffleReaderExec;
+pub use writer::RayShuffleWriterExec;

--- a/src/shuffle/ray_shuffle/reader.rs
+++ b/src/shuffle/ray_shuffle/reader.rs
@@ -102,13 +102,8 @@ impl ExecutionPlan for RayShuffleReaderExec {
         _context: Arc<TaskContext>,
     ) -> datafusion::common::Result<SendableRecordBatchStream> {
         let map = self.input_objects_map.read().unwrap();
-        let input_objects = map.get(&partition).expect(
-            format!(
-                "input objects for stage {} partition {}",
-                self.stage_id, partition
-            )
-            .as_str(),
-        );
+        let empty_input_objects = vec![];
+        let input_objects = map.get(&partition).unwrap_or(&empty_input_objects);
         println!(
             "RayShuffleReaderExec[stage={}].execute(input_partition={partition}) with {} shuffle inputs",
             self.stage_id,

--- a/src/shuffle/ray_shuffle/reader.rs
+++ b/src/shuffle/ray_shuffle/reader.rs
@@ -18,20 +18,23 @@ use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
 
+type PartitionId = usize;
+type StageId = usize;
+
 #[derive(Debug)]
 pub struct RayShuffleReaderExec {
     /// Query stage to read from
-    pub stage_id: usize,
+    pub stage_id: StageId,
     /// The output schema of the query stage being read from
     schema: SchemaRef,
     /// Output partitioning
     partitioning: Partitioning,
     /// Input streams from Ray object store
-    input_objects_map: RwLock<HashMap<usize, Vec<Vec<u8>>>>, // TODO(@lsf) can we not use Rwlock?
+    input_partitions_map: RwLock<HashMap<PartitionId, Vec<Vec<u8>>>>, // TODO(@lsf) can we not use Rwlock?
 }
 
 impl RayShuffleReaderExec {
-    pub fn new(stage_id: usize, schema: SchemaRef, partitioning: Partitioning) -> Self {
+    pub fn new(stage_id: StageId, schema: SchemaRef, partitioning: Partitioning) -> Self {
         let partitioning = match partitioning {
             Partitioning::Hash(expr, n) if expr.is_empty() => Partitioning::UnknownPartitioning(n),
             Partitioning::Hash(expr, n) => {
@@ -50,20 +53,20 @@ impl RayShuffleReaderExec {
             stage_id,
             schema,
             partitioning,
-            input_objects_map: RwLock::new(HashMap::new()),
+            input_partitions_map: RwLock::new(HashMap::new()),
         }
     }
 
-    pub fn set_input_objects(&self, partition: usize, input_objects: Vec<Vec<u8>>) {
+    pub fn set_input_partitions(&self, partition: PartitionId, input_partitions: Vec<Vec<u8>>) {
         println!(
             "RayShuffleReaderExec[stage={}].execute(input_partition={partition}) is set with {} shuffle inputs",
             self.stage_id,
-            input_objects.len(),
+            input_partitions.len(),
         );
-        self.input_objects_map
+        self.input_partitions_map
             .write()
             .unwrap()
-            .insert(partition, input_objects);
+            .insert(partition, input_partitions);
     }
 }
 
@@ -101,7 +104,7 @@ impl ExecutionPlan for RayShuffleReaderExec {
         partition: usize,
         _context: Arc<TaskContext>,
     ) -> datafusion::common::Result<SendableRecordBatchStream> {
-        let map = self.input_objects_map.read().unwrap();
+        let map = self.input_partitions_map.read().unwrap();
         let empty_input_objects = vec![];
         let input_objects = map.get(&partition).unwrap_or(&empty_input_objects);
         println!(

--- a/src/shuffle/ray_shuffle/reader.rs
+++ b/src/shuffle/ray_shuffle/reader.rs
@@ -25,19 +25,12 @@ pub struct RayShuffleReaderExec {
     schema: SchemaRef,
     /// Output partitioning
     partitioning: Partitioning,
-    /// Directory to read shuffle files from
-    pub shuffle_dir: String, // TODO(@lsf) remove
     /// Input streams from Ray object store
     input_objects: RwLock<Vec<Vec<u8>>>, // TODO(@lsf) can we not use Rwlock?
 }
 
 impl RayShuffleReaderExec {
-    pub fn new(
-        stage_id: usize,
-        schema: SchemaRef,
-        partitioning: Partitioning,
-        shuffle_dir: &str,
-    ) -> Self {
+    pub fn new(stage_id: usize, schema: SchemaRef, partitioning: Partitioning) -> Self {
         let partitioning = match partitioning {
             Partitioning::Hash(expr, n) if expr.is_empty() => Partitioning::UnknownPartitioning(n),
             Partitioning::Hash(expr, n) => {
@@ -56,7 +49,6 @@ impl RayShuffleReaderExec {
             stage_id,
             schema,
             partitioning,
-            shuffle_dir: shuffle_dir.to_string(),
             input_objects: RwLock::new(vec![]),
         }
     }

--- a/src/shuffle/ray_shuffle/reader.rs
+++ b/src/shuffle/ray_shuffle/reader.rs
@@ -1,0 +1,164 @@
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::ipc::reader::FileReader;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::Statistics;
+use datafusion::error::DataFusionError;
+use datafusion::execution::context::TaskContext;
+use datafusion::physical_expr::expressions::UnKnownColumn;
+use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::union::CombinedRecordBatchStream;
+use datafusion::physical_plan::{
+    DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream, SendableRecordBatchStream,
+};
+use futures::Stream;
+use glob::glob;
+use std::any::Any;
+use std::fmt::Formatter;
+use std::fs::File;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+#[derive(Debug)]
+pub struct RayShuffleReaderExec {
+    /// Query stage to read from
+    pub stage_id: usize,
+    /// The output schema of the query stage being read from
+    schema: SchemaRef,
+    /// Output partitioning
+    partitioning: Partitioning,
+    /// Directory to read shuffle files from
+    pub shuffle_dir: String,
+}
+
+impl RayShuffleReaderExec {
+    pub fn new(
+        stage_id: usize,
+        schema: SchemaRef,
+        partitioning: Partitioning,
+        shuffle_dir: &str,
+    ) -> Self {
+        let partitioning = match partitioning {
+            Partitioning::Hash(expr, n) if expr.is_empty() => Partitioning::UnknownPartitioning(n),
+            Partitioning::Hash(expr, n) => {
+                // workaround for DataFusion bug https://github.com/apache/arrow-datafusion/issues/5184
+                Partitioning::Hash(
+                    expr.into_iter()
+                        .filter(|e| e.as_any().downcast_ref::<UnKnownColumn>().is_none())
+                        .collect(),
+                    n,
+                )
+            }
+            _ => partitioning,
+        };
+
+        Self {
+            stage_id,
+            schema,
+            partitioning,
+            shuffle_dir: shuffle_dir.to_string(),
+        }
+    }
+}
+
+impl ExecutionPlan for RayShuffleReaderExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        self.partitioning.clone()
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        // TODO could be implemented in some cases
+        None
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> datafusion::common::Result<SendableRecordBatchStream> {
+        let pattern = format!(
+            "/{}/shuffle_{}_*_{partition}.arrow",
+            self.shuffle_dir, self.stage_id
+        );
+        let mut streams: Vec<SendableRecordBatchStream> = vec![];
+        for entry in glob(&pattern).expect("Failed to read glob pattern") {
+            let file = entry.unwrap();
+            println!(
+                "RayShuffleReaderExec partition {} reading from stage {} file {}",
+                partition,
+                self.stage_id,
+                file.display()
+            );
+            let reader = FileReader::try_new(File::open(&file)?, None)?;
+            let stream = LocalShuffleStream::new(reader);
+            if self.schema != stream.schema() {
+                return Err(DataFusionError::Internal(
+                    "Not all shuffle files have the same schema".to_string(),
+                ));
+            }
+            streams.push(Box::pin(stream));
+        }
+        Ok(Box::pin(CombinedRecordBatchStream::new(
+            self.schema.clone(),
+            streams,
+        )))
+    }
+
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "RayShuffleReaderExec(stage_id={}, input_partitioning={:?})",
+            self.stage_id, self.partitioning
+        )
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics::default()
+    }
+}
+
+struct LocalShuffleStream {
+    reader: FileReader<File>,
+}
+
+impl LocalShuffleStream {
+    pub fn new(reader: FileReader<File>) -> Self {
+        LocalShuffleStream { reader }
+    }
+}
+
+impl Stream for LocalShuffleStream {
+    type Item = datafusion::arrow::error::Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Some(batch) = self.reader.next() {
+            return Poll::Ready(Some(batch));
+        }
+        Poll::Ready(None)
+    }
+}
+
+impl RecordBatchStream for LocalShuffleStream {
+    fn schema(&self) -> SchemaRef {
+        self.reader.schema()
+    }
+}

--- a/src/shuffle/ray_shuffle/reader.rs
+++ b/src/shuffle/ray_shuffle/reader.rs
@@ -102,9 +102,15 @@ impl ExecutionPlan for RayShuffleReaderExec {
         _context: Arc<TaskContext>,
     ) -> datafusion::common::Result<SendableRecordBatchStream> {
         let map = self.input_objects_map.read().unwrap();
-        let input_objects = map.get(&partition).unwrap();
+        let input_objects = map.get(&partition).expect(
+            format!(
+                "input objects for stage {} partition {}",
+                self.stage_id, partition
+            )
+            .as_str(),
+        );
         println!(
-            "RayShuffleReaderExec[stage={}].execute(input_partition={partition})\nReading {} shuffle inputs",
+            "RayShuffleReaderExec[stage={}].execute(input_partition={partition}) with {} shuffle inputs",
             self.stage_id,
             input_objects.len(),
         );

--- a/src/shuffle/ray_shuffle/writer.rs
+++ b/src/shuffle/ray_shuffle/writer.rs
@@ -1,0 +1,109 @@
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::{Result, Statistics};
+use datafusion::execution::context::TaskContext;
+use datafusion::physical_expr::expressions::UnKnownColumn;
+use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+use datafusion::physical_plan::{
+    DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
+};
+use std::any::Any;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct RayShuffleWriterExec {
+    pub stage_id: usize,
+    pub(crate) plan: Arc<dyn ExecutionPlan>,
+    /// Output partitioning
+    partitioning: Partitioning,
+    /// Directory to write shuffle files from
+    pub shuffle_dir: String,
+    /// Metrics
+    pub metrics: ExecutionPlanMetricsSet,
+}
+
+impl RayShuffleWriterExec {
+    pub fn new(
+        stage_id: usize,
+        plan: Arc<dyn ExecutionPlan>,
+        partitioning: Partitioning,
+        shuffle_dir: &str,
+    ) -> Self {
+        let partitioning = match partitioning {
+            Partitioning::Hash(expr, n) if expr.is_empty() => Partitioning::UnknownPartitioning(n),
+            Partitioning::Hash(expr, n) => {
+                // workaround for DataFusion bug https://github.com/apache/arrow-datafusion/issues/5184
+                Partitioning::Hash(
+                    expr.into_iter()
+                        .filter(|e| e.as_any().downcast_ref::<UnKnownColumn>().is_none())
+                        .collect(),
+                    n,
+                )
+            }
+            _ => partitioning,
+        };
+
+        Self {
+            stage_id,
+            plan,
+            partitioning,
+            shuffle_dir: shuffle_dir.to_string(),
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+}
+
+impl ExecutionPlan for RayShuffleWriterExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.plan.schema()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        self.partitioning.clone()
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        // TODO in the case of a single partition of a sorted plan this could be implemented
+        None
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.plan.clone()]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        unimplemented!()
+    }
+
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "RayShuffleWriterExec(stage_id={}, output_partitioning={:?})",
+            self.stage_id, self.partitioning
+        )
+    }
+
+    fn execute(
+        &self,
+        input_partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        println!(
+            "RayShuffleWriterExec[stage={}].execute(input_partition={input_partition})",
+            self.stage_id
+        );
+        self.plan.execute(input_partition, context)
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics::default()
+    }
+}

--- a/src/shuffle/ray_shuffle/writer.rs
+++ b/src/shuffle/ray_shuffle/writer.rs
@@ -1,6 +1,6 @@
+use datafusion::arrow::compute::concat_batches;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::common::{Result, Statistics};
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_expr::expressions::UnKnownColumn;
@@ -114,9 +114,9 @@ impl ExecutionPlan for RayShuffleWriterExec {
                 Partitioning::Hash(_, _) => {
                     // TODO(@lsf) What happens if there are multiple RecordBatches
                     // assigned to the same writer?
-                    let mut writers: Vec<RecordBatch> = vec![];
+                    let mut writers: Vec<Vec<RecordBatch>> = vec![];
                     for _ in 0..partition_count {
-                        writers.push(RecordBatch::new_empty(schema.clone()));
+                        writers.push(vec![]);
                     }
 
                     let mut partitioner =
@@ -127,23 +127,24 @@ impl ExecutionPlan for RayShuffleWriterExec {
                     while let Some(result) = stream.next().await {
                         let input_batch = result?;
                         rows += input_batch.num_rows();
-
-                        println!(
-                            "ShuffleWriterExec[stage={}] writing batch:\n{}",
-                            stage_id,
-                            pretty_format_batches(&[input_batch.clone()])?
-                        );
-
                         partitioner.partition(input_batch, |output_partition, output_batch| {
-                            writers[output_partition] = output_batch;
+                            println!(
+                                "ShuffleWriterExec[stage={}] writing batch output (partition {})",
+                                stage_id, output_partition
+                            );
+                            writers[output_partition].push(output_batch);
                             Ok(())
                         })?;
                     }
                     println!(
-                        "RayShuffleWriterExec[stage={}] Finished processing stream with {rows} rows",
+                        "RayShuffleWriterExec[stage={}] finished processing stream with {rows} rows",
                         stage_id
                     );
-                    MemoryStream::try_new(writers, schema, None)
+                    let result_batches: Vec<_> = writers
+                        .iter()
+                        .map(|batches| concat_batches(&schema, batches).unwrap())
+                        .collect();
+                    MemoryStream::try_new(result_batches, schema, None)
                 }
                 _ => unimplemented!(),
             }

--- a/src/shuffle/ray_shuffle/writer.rs
+++ b/src/shuffle/ray_shuffle/writer.rs
@@ -18,19 +18,12 @@ pub struct RayShuffleWriterExec {
     pub(crate) plan: Arc<dyn ExecutionPlan>,
     /// Output partitioning
     partitioning: Partitioning,
-    /// Directory to write shuffle files from
-    pub shuffle_dir: String, // TODO(@lsf) remove
     /// Metrics
     pub metrics: ExecutionPlanMetricsSet,
 }
 
 impl RayShuffleWriterExec {
-    pub fn new(
-        stage_id: usize,
-        plan: Arc<dyn ExecutionPlan>,
-        partitioning: Partitioning,
-        shuffle_dir: &str,
-    ) -> Self {
+    pub fn new(stage_id: usize, plan: Arc<dyn ExecutionPlan>, partitioning: Partitioning) -> Self {
         let partitioning = match partitioning {
             Partitioning::Hash(expr, n) if expr.is_empty() => Partitioning::UnknownPartitioning(n),
             Partitioning::Hash(expr, n) => {
@@ -49,7 +42,6 @@ impl RayShuffleWriterExec {
             stage_id,
             plan,
             partitioning,
-            shuffle_dir: shuffle_dir.to_string(),
             metrics: ExecutionPlanMetricsSet::new(),
         }
     }

--- a/src/shuffle/ray_shuffle/writer.rs
+++ b/src/shuffle/ray_shuffle/writer.rs
@@ -14,11 +14,12 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct RayShuffleWriterExec {
     pub stage_id: usize,
+    /// The child execution plan
     pub(crate) plan: Arc<dyn ExecutionPlan>,
     /// Output partitioning
     partitioning: Partitioning,
     /// Directory to write shuffle files from
-    pub shuffle_dir: String,
+    pub shuffle_dir: String, // TODO(@lsf) remove
     /// Metrics
     pub metrics: ExecutionPlanMetricsSet,
 }


### PR DESCRIPTION
- [x] Add a flag for the Python RaySQL context so specify whether to use Ray for shuffle
- [x] Make ResultSet serializable across Python workers
- [x] Pass children ResultSets to RayShuffleReaderExec
- [x] Make RayShuffleReaderExec read from the input Python objects
- [ ] Make `ResultSet` picklable