### PR TITLE
Fixes for Ray-based shuffle

### DIFF
--- a/raysql/context.py
+++ b/raysql/context.py
@@ -31,6 +31,7 @@ def execute_query_stage(
     output_partitions_count = stage.get_output_partition_count()
     if output_partitions_count == 1:
         # reduce stage
+        print("Forcing reduce stage concurrency from {} to 1".format(concurrency))
         concurrency = 1
 
     print(
@@ -43,21 +44,20 @@ def execute_query_stage(
     # Each list is a 2-D array of (input partitions, output partitions).
     child_outputs = ray.get(child_futures)
 
-    def _get_worker_inputs(part: int) -> dict[int, list[ray.ObjectRef]]:
-        ret = {}
-        if not use_ray_shuffle:
-            return ret
-        return {c: get_child_inputs(part, outs) for c, outs in child_outputs}
-
-    def get_child_inputs(
-        part: int, inputs: list[list[ray.ObjectRef]]
-    ) -> list[ray.ObjectRef]:
+    def _get_worker_inputs(part: int) -> list[tuple[int, int, int, ray.ObjectRef]]:
         ret = []
-        for lst in inputs:
-            if isinstance(lst, list):
-                ret.append(lst[part])
-            elif part == 0:
-                ret.append(lst)
+        if not use_ray_shuffle:
+            return []
+        for child_stage_id, child_futures in child_outputs:
+            for i, lst in enumerate(child_futures):
+                if isinstance(lst, list):
+                    for j, f in enumerate(lst):
+                        if concurrency == 1 or j == part:
+                            # If concurrency is 1, pass in all shuffle partitions. Otherwise,
+                            # only pass in the partitions that match the current worker partition.
+                            ret.append((child_stage_id, i, j, f))
+                elif concurrency == 1 or part == 0:
+                    ret.append((child_stage_id, i, 0, lst))
         return ret
 
     # if we are using disk-based shuffle, wait until the child stages to finish

--- a/raysql/main.py
+++ b/raysql/main.py
@@ -43,10 +43,30 @@ def load_query(n: int) -> str:
 def tpchq(ctx: RaySqlContext, q: int = 14):
     sql = load_query(q)
     result_set = ray.get(ctx.sql.remote(sql))
-    print("Result:")
-    print(ResultSet(result_set))
+    return result_set
 
 
-use_ray_shuffle = False
-ctx = setup_context(use_ray_shuffle)
-tpchq(ctx)
+def compare(q: int):
+    ctx = setup_context(False)
+    result_set_truth = tpchq(ctx, q)
+
+    ctx = setup_context(True)
+    result_set_ray = tpchq(ctx, q)
+
+    assert result_set_truth == result_set_ray, (
+        q,
+        ResultSet(result_set_truth),
+        ResultSet(result_set_ray),
+    )
+
+
+# use_ray_shuffle = True
+# ctx = setup_context(use_ray_shuffle)
+# result_set = tpchq(ctx, 1)
+# print("Result:")
+# print(ResultSet(result_set))
+
+for i in range(1, 22 + 1):
+    if i == 15:
+        continue
+    compare(i)

--- a/raysql/worker.py
+++ b/raysql/worker.py
@@ -19,11 +19,10 @@ class Worker:
 
         if self.debug:
             print(
-                "Worker executing plan {} partition #{} with {} shuffle inputs:\n{}".format(
+                "Worker executing plan {} partition #{} with {} shuffle inputs".format(
                     plan.display(),
                     part,
                     {i: len(parts) for i, parts in input_partitions_map.items()},
-                    plan.display_indent(),
                 )
             )
 

--- a/raysql/worker.py
+++ b/raysql/worker.py
@@ -13,26 +13,27 @@ class Worker:
         self,
         plan_bytes: bytes,
         part: int,
-        input_partitions_map: dict[int, list[ray.ObjectRef]],
+        input_partition_refs: list[tuple[int, int, int, ray.ObjectRef]],
     ) -> list[bytes]:
         plan = deserialize_execution_plan(plan_bytes)
 
         if self.debug:
             print(
-                "Worker executing plan {} partition #{} with {} shuffle inputs".format(
+                "Worker executing plan {} partition #{} with shuffle inputs {}".format(
                     plan.display(),
                     part,
-                    {i: len(parts) for i, parts in input_partitions_map.items()},
+                    [(s, i, j) for s, i, j, _ in input_partition_refs],
                 )
             )
 
-        input_partitions_map = {
-            i: ray.get(parts) for i, parts in input_partitions_map.items()
-        }
+        input_data = ray.get([f for _, _, _, f in input_partition_refs])
+        input_partitions = [
+            (s, j, d) for (s, _, j, _), d in zip(input_partition_refs, input_data)
+        ]
         # This is delegating to DataFusion for execution, but this would be a good place
         # to plug in other execution engines by translating the plan into another engine's plan
         # (perhaps via Substrait, once DataFusion supports converting a physical plan to Substrait)
-        result_set = self.ctx.execute_partition(plan, part, input_partitions_map)
+        result_set = self.ctx.execute_partition(plan, part, input_partitions)
 
         ret = result_set.tobyteslist()
         return ret[0] if len(ret) == 1 else ret

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,7 @@
 use crate::planner::{make_execution_graph, PyExecutionGraph};
 use crate::shuffle::{RayShuffleReaderExec, ShuffleCodec};
 use crate::utils::wait_for_future;
+use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -15,14 +16,13 @@ use datafusion::prelude::*;
 use datafusion_proto::bytes::{
     physical_plan_from_bytes_with_extension_codec, physical_plan_to_bytes_with_extension_codec,
 };
+use datafusion_python::errors::py_datafusion_err;
 use datafusion_python::physical_plan::PyExecutionPlan;
 use futures::StreamExt;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
 use std::collections::HashMap;
 use std::sync::Arc;
-use datafusion::arrow::error::ArrowError;
-use datafusion_python::errors::py_datafusion_err;
 use tokio::runtime::Runtime;
 use tokio::task::JoinHandle;
 
@@ -135,13 +135,24 @@ fn _set_inputs_for_ray_shuffle_reader(
     if let Some(reader_exec) = plan.as_any().downcast_ref::<RayShuffleReaderExec>() {
         let stage_id = reader_exec.stage_id;
         // iterate over inputs, wrap in PyBytes and set as input objects
-        let input_partitions_map = inputs.as_ref(py).downcast::<PyDict>().map_err(|e| DataFusionError::Execution(format!("{}", e)))?;
+        let input_partitions_map = inputs
+            .as_ref(py)
+            .downcast::<PyDict>()
+            .map_err(|e| DataFusionError::Execution(format!("{}", e)))?;
         match input_partitions_map.get_item(stage_id) {
             Some(input_partitions) => {
-                let input_partitions = input_partitions.downcast::<PyList>().map_err(|e| DataFusionError::Execution(format!("{}", e)))?;
+                let input_partitions = input_partitions
+                    .downcast::<PyList>()
+                    .map_err(|e| DataFusionError::Execution(format!("{}", e)))?;
                 let input_objects = input_partitions
                     .iter()
-                    .map(|input| input.downcast::<PyBytes>().expect("expected PyBytes").as_bytes().to_vec())
+                    .map(|input| {
+                        input
+                            .downcast::<PyBytes>()
+                            .expect("expected PyBytes")
+                            .as_bytes()
+                            .to_vec()
+                    })
                     .collect();
                 reader_exec.set_input_partitions(part, input_objects)?;
             }
@@ -207,16 +218,33 @@ impl PyResultSet {
     }
 }
 
+fn _read_pybytes(pyobj: &PyAny, batches: &mut Vec<PyRecordBatch>) -> PyResult<()> {
+    let pybytes = pyobj
+        .downcast::<PyBytes>()
+        .map_err(|e| py_datafusion_err(e))?;
+    let reader = StreamReader::try_new(pybytes.as_bytes(), None).map_err(py_datafusion_err)?;
+    for batch in reader {
+        let batch = batch.map_err(|e| py_datafusion_err(e))?;
+        batches.push(PyRecordBatch::new(batch));
+    }
+    Ok(())
+}
+
 #[pymethods]
 impl PyResultSet {
+    /// This constructor takes either a list of bytes or a single bytes object.
     #[new]
-    fn py_new(py_obj: &PyBytes) -> PyResult<Self> {
-        let reader = StreamReader::try_new(py_obj.as_bytes(), None).map_err(py_datafusion_err)?;
+    fn py_new(pyobj: &PyAny) -> PyResult<Self> {
         let mut batches = vec![];
-        for batch in reader {
-            let batch = batch.map_err(|e| py_datafusion_err(e))?;
-            batches.push(PyRecordBatch::new(batch));
-        }
+        match pyobj.downcast::<PyList>() {
+            Ok(pylist) => {
+                for item in pylist.iter() {
+                    _read_pybytes(item, &mut batches)?;
+                }
+                Ok(())
+            }
+            _ => _read_pybytes(&pyobj, &mut batches),
+        }?;
         Ok(Self { batches })
     }
 
@@ -249,13 +277,14 @@ impl PyRecordBatch {
 impl PyRecordBatch {
     #[new]
     fn py_new(py_obj: &PyBytes) -> PyResult<Self> {
-        let reader = StreamReader::try_new(py_obj.as_bytes(), None).map_err(|e| py_datafusion_err(e))?;
+        let reader =
+            StreamReader::try_new(py_obj.as_bytes(), None).map_err(|e| py_datafusion_err(e))?;
         let mut batches = vec![];
         for r in reader {
             batches.push(r.map_err(|e| py_datafusion_err(e))?);
         }
         if let Some(batch) = batches.pop() {
-            Ok(Self { batch})
+            Ok(Self { batch })
         } else {
             Err(py_datafusion_err("no batches"))
         }
@@ -273,7 +302,6 @@ impl PyRecordBatch {
         write_batch(&mut buf, &self.batch).map_err(|e| py_datafusion_err(e))?;
         Ok(PyBytes::new(py, &buf).into())
     }
-
 }
 
 fn write_batch(mut buf: &mut Vec<u8>, batch: &RecordBatch) -> Result<(), ArrowError> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -140,7 +140,9 @@ fn _set_inputs_for_ray_shuffle_reader(
             .downcast::<PyList>()
             .map_err(|e| DataFusionError::Execution(format!("{}", e)))?;
         for item in input_partitions.iter() {
-            let pytuple = item.downcast::<PyTuple>().unwrap();
+            let pytuple = item
+                .downcast::<PyTuple>()
+                .map_err(|e| DataFusionError::Execution(format!("{}", e)))?;
             let stage_id = pytuple
                 .get_item(0)
                 .map_err(|e| DataFusionError::Execution(format!("{}", e)))?


### PR DESCRIPTION
Things fixed:
* `PyResultSet` can now take a list of bytes from worker execution result.
* Passing the correct partitions to the correct reducers.

All queries passed except:
* q15 view not supported (known issue)

Tested on:
* sf=1, 2 workers, single node
* sf=1, 4 workers, single node