### PR TITLE
Add support for DDL statements, such as `CREATE VIEW`

### DIFF
--- a/raysql/__init__.py
+++ b/raysql/__init__.py
@@ -10,6 +10,7 @@ from ._raysql_internal import (
     execute_partition,
     serialize_execution_plan,
     deserialize_execution_plan,
+    empty_result_set
 )
 from .context import RaySqlContext
 

--- a/raysql/context.py
+++ b/raysql/context.py
@@ -125,6 +125,12 @@ class RaySqlContext:
         self.ctx.register_parquet(table_name, path)
 
     def sql(self, sql: str) -> ResultSet:
+        # TODO we should parse sql and inspect the plan rather than
+        # perform a string comparison here
+        if 'create view' in sql or 'drop view' in sql:
+            self.ctx.sql(sql)
+            return raysql.empty_result_set()
+
         graph = self.ctx.plan(sql)
         final_stage_id = graph.get_final_query_stage().id()
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,9 @@ extern crate core;
 use pyo3::prelude::*;
 
 mod proto;
-use crate::context::{deserialize_execution_plan, execute_partition, serialize_execution_plan};
+use crate::context::{
+    deserialize_execution_plan, empty_result_set, execute_partition, serialize_execution_plan,
+};
 pub use proto::generated::protobuf;
 
 pub mod context;
@@ -22,5 +24,6 @@ fn _raysql_internal(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(execute_partition, m)?)?;
     m.add_function(wrap_pyfunction!(serialize_execution_plan, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize_execution_plan, m)?)?;
+    m.add_function(wrap_pyfunction!(empty_result_set, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
TPC-H query 15 requires support for create/drop view. These SQL statements need to be executed directly against DataFusion's context.