### PR TITLE
Use PyArrow for zero-copy interaction with the Ray Object Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 __pycache__
 venv
 *.so
+*.log
+results-sf*

--- a/raysql/__init__.py
+++ b/raysql/__init__.py
@@ -10,7 +10,6 @@ from ._raysql_internal import (
     execute_partition,
     serialize_execution_plan,
     deserialize_execution_plan,
-    empty_result_set
 )
 from .context import RaySqlContext
 

--- a/raysql/__init__.py
+++ b/raysql/__init__.py
@@ -5,8 +5,8 @@ except ImportError:
 
 from ._raysql_internal import (
     Context,
+    ExecutionGraph,
     QueryStage,
-    ResultSet,
     execute_partition,
     serialize_execution_plan,
     deserialize_execution_plan,

--- a/raysql/context.py
+++ b/raysql/context.py
@@ -1,14 +1,80 @@
+import json
+import os
+import time
+from typing import Iterable
+
+import pyarrow as pa
 import ray
 
 import raysql
-from raysql import Context, QueryStage, ResultSet, ray_utils
+from raysql import Context, ExecutionGraph, QueryStage
 
 
-@ray.remote
+def schedule_execution(
+    graph: ExecutionGraph,
+    stage_id: int,
+    is_final_stage: bool,
+) -> list[ray.ObjectRef]:
+    stage = graph.get_query_stage(stage_id)
+    # execute child stages first
+    # A list of (stage ID, list of futures) for each child stage
+    # Each list is a 2-D array of (input partitions, output partitions).
+    child_outputs = []
+    for child_id in stage.get_child_stage_ids():
+        child_outputs.append((child_id, schedule_execution(graph, child_id, False)))
+        # child_outputs.append((child_id, schedule_execution(graph, child_id)))
+
+    concurrency = stage.get_input_partition_count()
+    output_partitions_count = stage.get_output_partition_count()
+    if is_final_stage:
+        print("Forcing reduce stage concurrency from {} to 1".format(concurrency))
+        concurrency = 1
+
+    print(
+        "Scheduling query stage #{} with {} input partitions and {} output partitions".format(
+            stage.id(), concurrency, output_partitions_count
+        )
+    )
+
+    def _get_worker_inputs(
+        part: int,
+    ) -> tuple[list[tuple[int, int, int]], list[ray.ObjectRef]]:
+        ids = []
+        futures = []
+        for child_stage_id, child_futures in child_outputs:
+            for i, lst in enumerate(child_futures):
+                if isinstance(lst, list):
+                    for j, f in enumerate(lst):
+                        if concurrency == 1 or j == part:
+                            # If concurrency is 1, pass in all shuffle partitions. Otherwise,
+                            # only pass in the partitions that match the current worker partition.
+                            ids.append((child_stage_id, i, j))
+                            futures.append(f)
+                elif concurrency == 1 or part == 0:
+                    ids.append((child_stage_id, i, 0))
+                    futures.append(lst)
+        return ids, futures
+
+    # schedule the actual execution workers
+    plan_bytes = raysql.serialize_execution_plan(stage.get_execution_plan())
+    futures = []
+    opt = {}
+    opt["resources"] = {"worker": 1e-3}
+    opt["num_returns"] = output_partitions_count
+    for part in range(concurrency):
+        ids, inputs = _get_worker_inputs(part)
+        futures.append(
+            execute_query_partition.options(**opt).remote(
+                stage_id, plan_bytes, part, ids, *inputs
+            )
+        )
+    return futures
+
+
+@ray.remote(num_cpus=0)
 def execute_query_stage(
     query_stages: list[QueryStage],
     stage_id: int,
-    num_workers: int,
     use_ray_shuffle: bool,
 ) -> tuple[int, list[ray.ObjectRef]]:
     """
@@ -22,9 +88,7 @@ def execute_query_stage(
     child_futures = []
     for child_id in stage.get_child_stage_ids():
         child_futures.append(
-            execute_query_stage.options(**ray_utils.current_node_aff()).remote(
-                query_stages, child_id, num_workers, use_ray_shuffle
-            )
+            execute_query_stage.remote(query_stages, child_id, use_ray_shuffle)
         )
 
     # if the query stage has a single output partition then we need to execute for the output
@@ -46,21 +110,25 @@ def execute_query_stage(
     # Each list is a 2-D array of (input partitions, output partitions).
     child_outputs = ray.get(child_futures)
 
-    def _get_worker_inputs(part: int) -> list[tuple[int, int, int, ray.ObjectRef]]:
-        ret = []
-        if not use_ray_shuffle:
-            return []
-        for child_stage_id, child_futures in child_outputs:
-            for i, lst in enumerate(child_futures):
-                if isinstance(lst, list):
-                    for j, f in enumerate(lst):
-                        if concurrency == 1 or j == part:
-                            # If concurrency is 1, pass in all shuffle partitions. Otherwise,
-                            # only pass in the partitions that match the current worker partition.
-                            ret.append((child_stage_id, i, j, f))
-                elif concurrency == 1 or part == 0:
-                    ret.append((child_stage_id, i, 0, lst))
-        return ret
+    def _get_worker_inputs(
+        part: int,
+    ) -> tuple[list[tuple[int, int, int]], list[ray.ObjectRef]]:
+        ids = []
+        futures = []
+        if use_ray_shuffle:
+            for child_stage_id, child_futures in child_outputs:
+                for i, lst in enumerate(child_futures):
+                    if isinstance(lst, list):
+                        for j, f in enumerate(lst):
+                            if concurrency == 1 or j == part:
+                                # If concurrency is 1, pass in all shuffle partitions. Otherwise,
+                                # only pass in the partitions that match the current worker partition.
+                                ids.append((child_stage_id, i, j))
+                                futures.append(f)
+                    elif concurrency == 1 or part == 0:
+                        ids.append((child_stage_id, i, 0))
+                        futures.append(lst)
+        return ids, futures
 
     # if we are using disk-based shuffle, wait until the child stages to finish
     # writing the shuffle files to disk first.
@@ -75,9 +143,10 @@ def execute_query_stage(
     if use_ray_shuffle:
         opt["num_returns"] = output_partitions_count
     for part in range(concurrency):
+        ids, inputs = _get_worker_inputs(part)
         futures.append(
             execute_query_partition.options(**opt).remote(
-                plan_bytes, part, _get_worker_inputs(part)
+                stage_id, plan_bytes, part, ids, *inputs
             )
         )
 
@@ -86,29 +155,39 @@ def execute_query_stage(
 
 @ray.remote
 def execute_query_partition(
+    stage_id: int,
     plan_bytes: bytes,
     part: int,
-    input_partition_refs: list[tuple[int, int, int, ray.ObjectRef]],
-) -> list[bytes]:
+    input_partition_ids: list[tuple[int, int, int]],
+    *input_partitions: list[pa.RecordBatch],
+) -> Iterable[pa.RecordBatch]:
+    start_time = time.time()
     plan = raysql.deserialize_execution_plan(plan_bytes)
-    print(
-        "Worker executing plan {} partition #{} with shuffle inputs {}".format(
-            plan.display(),
-            part,
-            [(s, i, j) for s, i, j, _ in input_partition_refs],
-        )
-    )
-
-    input_data = ray.get([f for _, _, _, f in input_partition_refs])
-    input_partitions = [
-        (s, j, d) for (s, _, j, _), d in zip(input_partition_refs, input_data)
+    # print(
+    #     "Worker executing plan {} partition #{} with shuffle inputs {}".format(
+    #         plan.display(),
+    #         part,
+    #         input_partition_ids,
+    #     )
+    # )
+    partitions = [
+        (s, j, p) for (s, _, j), p in zip(input_partition_ids, input_partitions)
     ]
     # This is delegating to DataFusion for execution, but this would be a good place
     # to plug in other execution engines by translating the plan into another engine's plan
     # (perhaps via Substrait, once DataFusion supports converting a physical plan to Substrait)
-    result_set = raysql.execute_partition(plan, part, input_partitions)
-
-    ret = result_set.tobyteslist()
+    ret = raysql.execute_partition(plan, part, partitions)
+    duration = time.time() - start_time
+    event = {
+        "cat": f"{stage_id}-{part}",
+        "name": f"{stage_id}-{part}",
+        "pid": ray.util.get_node_ip_address(),
+        "tid": os.getpid(),
+        "ts": int(start_time * 1_000_000),
+        "dur": int(duration * 1_000_000),
+        "ph": "X",
+    }
+    print(json.dumps(event), end=",")
     return ret[0] if len(ret) == 1 else ret
 
 
@@ -124,30 +203,33 @@ class RaySqlContext:
     def register_parquet(self, table_name: str, path: str):
         self.ctx.register_parquet(table_name, path)
 
-    def sql(self, sql: str) -> ResultSet:
+    def sql(self, sql: str) -> pa.RecordBatch:
         # TODO we should parse sql and inspect the plan rather than
         # perform a string comparison here
-        if 'create view' in sql or 'drop view' in sql:
+        sql_str = sql.lower()
+        if "create view" in sql_str or "drop view" in sql_str:
             self.ctx.sql(sql)
-            return raysql.empty_result_set()
+            return []
 
         graph = self.ctx.plan(sql)
         final_stage_id = graph.get_final_query_stage().id()
-
-        # serialize the query stages and store in Ray object store
-        query_stages = [
-            raysql.serialize_execution_plan(
-                graph.get_query_stage(i).get_execution_plan()
+        if self.use_ray_shuffle:
+            partitions = schedule_execution(graph, final_stage_id, True)
+        else:
+            # serialize the query stages and store in Ray object store
+            query_stages = [
+                raysql.serialize_execution_plan(
+                    graph.get_query_stage(i).get_execution_plan()
+                )
+                for i in range(final_stage_id + 1)
+            ]
+            # schedule execution
+            future = execute_query_stage.remote(
+                query_stages,
+                final_stage_id,
+                self.use_ray_shuffle,
             )
-            for i in range(final_stage_id + 1)
-        ]
-
-        # schedule execution
-        future = execute_query_stage.options(**ray_utils.current_node_aff()).remote(
-            query_stages, final_stage_id, self.num_workers, self.use_ray_shuffle
-        )
-        _, partitions = ray.get(future)
-        # final stage should have a concurrency of 1
-        assert len(partitions) == 1, partitions
+            _, partitions = ray.get(future)
+        # assert len(partitions) == 1, len(partitions)
         result_set = ray.get(partitions[0])
         return result_set

--- a/raysql/main.py
+++ b/raysql/main.py
@@ -1,8 +1,9 @@
 import time
 import os
 
+from pyarrow import csv as pacsv
 import ray
-from raysql import RaySqlContext, ResultSet
+from raysql import RaySqlContext
 
 NUM_CPUS_PER_WORKER = 8
 
@@ -10,6 +11,10 @@ SF = 10
 DATA_DIR = f"/mnt/data0/tpch/sf{SF}-parquet"
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 QUERIES_DIR = os.path.join(SCRIPT_DIR, f"../sqlbench-h/queries/sf={SF}")
+RESULTS_DIR = f"results-sf{SF}"
+TRUTH_DIR = (
+    "/home/ubuntu/raysort/ray-sql/sqlbench-runners/spark/{RESULTS_DIR}/{RESULTS_DIR}"
+)
 
 
 def setup_context(use_ray_shuffle: bool, num_workers: int = 2) -> RaySqlContext:
@@ -40,13 +45,30 @@ def tpch_query(ctx: RaySqlContext, q: int = 1):
     return result_set
 
 
-def tpch_timing(ctx: RaySqlContext, q: int = 1, print_result: bool = False):
+def tpch_timing(
+    ctx: RaySqlContext,
+    q: int = 1,
+    print_result: bool = False,
+    write_result: bool = False,
+):
     sql = load_query(q)
     start = time.perf_counter()
     result = ctx.sql(sql)
-    if print_result:
-        print(ResultSet(result))
     end = time.perf_counter()
+    if print_result:
+        print("Result:", result)
+        if isinstance(result, list):
+            for r in result:
+                print(r.to_pandas())
+        else:
+            print(result.to_pandas())
+    if write_result:
+        opt = pacsv.WriteOptions(quoting_style="none")
+        if isinstance(result, list):
+            for r in result:
+                pacsv.write_csv(r, f"{RESULTS_DIR}/q{q}.csv", write_options=opt)
+        else:
+            pacsv.write_csv(result, f"{RESULTS_DIR}/q{q}.csv", write_options=opt)
     return end - start
 
 
@@ -59,21 +81,25 @@ def compare(q: int):
 
     assert result_set_truth == result_set_ray, (
         q,
-        ResultSet(result_set_truth),
-        ResultSet(result_set_ray),
+        result_set_truth,
+        result_set_ray,
     )
 
 
 def tpch_bench():
     ray.init("auto")
     num_workers = int(ray.cluster_resources().get("worker", 1)) * NUM_CPUS_PER_WORKER
-    ctx = setup_context(True, num_workers)
+    use_ray_shuffle = False
+    ctx = setup_context(use_ray_shuffle, num_workers)
+    # t = tpch_timing(ctx, 11, print_result=True)
+    # print(f"query,{t},{use_ray_shuffle},{num_workers}")
+    # return
     run_id = time.strftime("%Y-%m-%d-%H-%M-%S")
     with open(f"results-sf{SF}-{run_id}.csv", "w") as fout:
         for i in range(1, 22 + 1):
             if i == 15:
                 continue
-            result = tpch_timing(ctx, i)
+            result = tpch_timing(ctx, i, write_result=True)
             print(f"query,{i},{result}")
             print(f"query,{i},{result}", file=fout, flush=True)
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -46,9 +46,7 @@ impl PyContext {
         let mem_pool_size = 1024 * 1024 * 1024;
         let runtime_config = datafusion::execution::runtime_env::RuntimeConfig::new()
             .with_memory_pool(Arc::new(FairSpillPool::new(mem_pool_size)))
-            .with_disk_manager(DiskManagerConfig::new_specified(vec![
-                "/mnt/data0/tmp".into()
-            ]));
+            .with_disk_manager(DiskManagerConfig::new_specified(vec!["/tmp".into()]));
         let runtime = Arc::new(RuntimeEnv::new(runtime_config)?);
         let ctx = SessionContext::with_config_rt(config, runtime);
         Ok(Self {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,11 +1,8 @@
 use crate::planner::{make_execution_graph, PyExecutionGraph};
 use crate::shuffle::{RayShuffleReaderExec, ShuffleCodec};
 use crate::utils::wait_for_future;
-use datafusion::arrow::error::ArrowError;
-use datafusion::arrow::ipc::reader::StreamReader;
-use datafusion::arrow::ipc::writer::StreamWriter;
+use datafusion::arrow::pyarrow::PyArrowConvert;
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::config::Extensions;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
@@ -17,15 +14,16 @@ use datafusion::prelude::*;
 use datafusion_proto::bytes::{
     physical_plan_from_bytes_with_extension_codec, physical_plan_to_bytes_with_extension_codec,
 };
-use datafusion_python::errors::py_datafusion_err;
 use datafusion_python::physical_plan::PyExecutionPlan;
 use futures::StreamExt;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyList, PyLong, PyTuple};
+use pyo3::types::{PyList, PyLong, PyTuple};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tokio::task::JoinHandle;
+
+type PyResultSet = Vec<PyObject>;
 
 #[pyclass(name = "Context", module = "raysql", subclass)]
 pub struct PyContext {
@@ -48,7 +46,9 @@ impl PyContext {
         let mem_pool_size = 1024 * 1024 * 1024;
         let runtime_config = datafusion::execution::runtime_env::RuntimeConfig::new()
             .with_memory_pool(Arc::new(FairSpillPool::new(mem_pool_size)))
-            .with_disk_manager(DiskManagerConfig::new_specified(vec!["/tmp".into()]));
+            .with_disk_manager(DiskManagerConfig::new_specified(vec![
+                "/mnt/data0/tmp".into()
+            ]));
         let runtime = Arc::new(RuntimeEnv::new(runtime_config)?);
         let ctx = SessionContext::with_config_rt(config, runtime);
         Ok(Self {
@@ -92,7 +92,9 @@ impl PyContext {
         let graph = make_execution_graph(plan.clone(), self.use_ray_shuffle)?;
 
         // debug logging
-        for stage in graph.query_stages.values() {
+        let mut stages = graph.query_stages.values().collect::<Vec<_>>();
+        stages.sort_by_key(|s| s.id);
+        for stage in stages {
             println!(
                 "Query stage #{}:\n{}",
                 stage.id,
@@ -109,21 +111,27 @@ impl PyContext {
         plan: PyExecutionPlan,
         part: usize,
         inputs: PyObject,
+        py: Python,
     ) -> PyResultSet {
-        execute_partition(plan, part, inputs)
+        execute_partition(plan, part, inputs, py)
     }
 }
 
 #[pyfunction]
-pub fn execute_partition(plan: PyExecutionPlan, part: usize, inputs: PyObject) -> PyResultSet {
-    let batches = _execute_partition(plan, part, inputs)
+pub fn execute_partition(
+    plan: PyExecutionPlan,
+    part: usize,
+    inputs: PyObject,
+    py: Python,
+) -> PyResultSet {
+    _execute_partition(plan, part, inputs)
         .unwrap()
-        .iter()
-        .map(|batch| PyRecordBatch::new(batch.clone())) // TODO(@lsf): avoid clone?
-        .collect();
-    PyResultSet::new(batches)
+        .into_iter()
+        .map(|batch| batch.to_pyarrow(py).unwrap()) // TODO(@lsf) handle error
+        .collect()
 }
 
+// TODO(@lsf) change this to use pickle
 #[pyfunction]
 pub fn serialize_execution_plan(plan: PyExecutionPlan) -> PyResult<Vec<u8>> {
     let codec = ShuffleCodec {};
@@ -143,16 +151,11 @@ pub fn deserialize_execution_plan(bytes: Vec<u8>) -> PyResult<PyExecutionPlan> {
 fn _set_inputs_for_ray_shuffle_reader(
     plan: Arc<dyn ExecutionPlan>,
     part: usize,
-    inputs: &PyObject,
-    py: Python,
+    input_partitions: &PyList,
 ) -> Result<()> {
     if let Some(reader_exec) = plan.as_any().downcast_ref::<RayShuffleReaderExec>() {
         let exec_stage_id = reader_exec.stage_id;
         // iterate over inputs, wrap in PyBytes and set as input objects
-        let input_partitions = inputs
-            .as_ref(py)
-            .downcast::<PyList>()
-            .map_err(|e| DataFusionError::Execution(format!("{}", e)))?;
         for item in input_partitions.iter() {
             let pytuple = item
                 .downcast::<PyTuple>()
@@ -174,18 +177,17 @@ fn _set_inputs_for_ray_shuffle_reader(
                 .map_err(|e| DataFusionError::Execution(format!("{}", e)))?
                 .extract::<usize>()
                 .map_err(|e| DataFusionError::Execution(format!("{}", e)))?;
-            let bytes = pytuple
-                .get_item(2)
-                .map_err(|e| DataFusionError::Execution(format!("{}", e)))?
-                .downcast::<PyBytes>()
-                .map_err(|e| DataFusionError::Execution(format!("{}", e)))?
-                .as_bytes()
-                .to_vec();
-            reader_exec.add_input_partition(part, bytes)?;
+            let batch = RecordBatch::from_pyarrow(
+                pytuple
+                    .get_item(2)
+                    .map_err(|e| DataFusionError::Execution(format!("{}", e)))?,
+            )
+            .map_err(|e| DataFusionError::Execution(format!("{}", e)))?;
+            reader_exec.add_input_partition(part, batch)?;
         }
     } else {
         for child in plan.children() {
-            _set_inputs_for_ray_shuffle_reader(child, part, inputs, py)?;
+            _set_inputs_for_ray_shuffle_reader(child, part, input_partitions)?;
         }
     }
     Ok(())
@@ -209,7 +211,11 @@ fn _execute_partition(
         Extensions::default(),
     )?);
     Python::with_gil(|py| {
-        _set_inputs_for_ray_shuffle_reader(plan.plan.clone(), part, &inputs, py)
+        let input_partitions = inputs
+            .as_ref(py)
+            .downcast::<PyList>()
+            .map_err(|e| DataFusionError::Execution(format!("{}", e)))?;
+        _set_inputs_for_ray_shuffle_reader(plan.plan.clone(), part, &input_partitions)
     })?;
 
     // create a Tokio runtime to run the async code
@@ -227,115 +233,4 @@ fn _execute_partition(
     // block and wait on future
     let results = rt.block_on(fut).unwrap()?;
     Ok(results)
-}
-
-#[pyclass(name = "ResultSet", module = "raysql", subclass)]
-pub struct PyResultSet {
-    batches: Vec<PyRecordBatch>,
-}
-
-impl PyResultSet {
-    fn new(batches: Vec<PyRecordBatch>) -> Self {
-        Self { batches }
-    }
-    fn empty() -> Self {
-        Self { batches: vec![] }
-    }
-}
-
-#[pyfunction]
-pub fn empty_result_set() -> PyResultSet {
-    PyResultSet::empty()
-}
-
-fn _read_pybytes(pyobj: &PyAny, batches: &mut Vec<PyRecordBatch>) -> PyResult<()> {
-    let pybytes = pyobj
-        .downcast::<PyBytes>()
-        .map_err(|e| py_datafusion_err(e))?;
-    let reader = StreamReader::try_new(pybytes.as_bytes(), None).map_err(py_datafusion_err)?;
-    for batch in reader {
-        let batch = batch.map_err(|e| py_datafusion_err(e))?;
-        batches.push(PyRecordBatch::new(batch));
-    }
-    Ok(())
-}
-
-#[pymethods]
-impl PyResultSet {
-    /// This constructor takes either a list of bytes or a single bytes object.
-    #[new]
-    fn py_new(pyobj: &PyAny) -> PyResult<Self> {
-        let mut batches = vec![];
-        match pyobj.downcast::<PyList>() {
-            Ok(pylist) => {
-                for item in pylist.iter() {
-                    _read_pybytes(item, &mut batches)?;
-                }
-                Ok(())
-            }
-            _ => _read_pybytes(&pyobj, &mut batches),
-        }?;
-        Ok(Self { batches })
-    }
-
-    fn __repr__(&self) -> PyResult<String> {
-        let batches: Vec<RecordBatch> = self.batches.iter().map(|b| b.batch.clone()).collect();
-        Ok(format!("{}", pretty_format_batches(&batches).unwrap()))
-    }
-
-    fn tobyteslist(&self, py: Python) -> PyResult<PyObject> {
-        let mut items = vec![];
-        for batch in &self.batches {
-            items.push(batch.tobytes(py)?);
-        }
-        Ok(PyList::new(py, &items).into())
-    }
-}
-
-#[pyclass(name = "RecordBatch", module = "raysql", subclass)]
-pub struct PyRecordBatch {
-    pub(crate) batch: RecordBatch,
-}
-
-impl PyRecordBatch {
-    fn new(batch: RecordBatch) -> Self {
-        Self { batch }
-    }
-}
-
-#[pymethods]
-impl PyRecordBatch {
-    #[new]
-    fn py_new(py_obj: &PyBytes) -> PyResult<Self> {
-        let reader =
-            StreamReader::try_new(py_obj.as_bytes(), None).map_err(|e| py_datafusion_err(e))?;
-        let mut batches = vec![];
-        for r in reader {
-            batches.push(r.map_err(|e| py_datafusion_err(e))?);
-        }
-        if let Some(batch) = batches.pop() {
-            Ok(Self { batch })
-        } else {
-            Err(py_datafusion_err("no batches"))
-        }
-    }
-
-    fn __repr__(&self) -> PyResult<String> {
-        Ok(format!(
-            "{}",
-            pretty_format_batches(&[self.batch.clone()]).unwrap()
-        ))
-    }
-
-    fn tobytes(&self, py: Python) -> PyResult<PyObject> {
-        let mut buf = Vec::<u8>::new();
-        write_batch(&mut buf, &self.batch).map_err(|e| py_datafusion_err(e))?;
-        Ok(PyBytes::new(py, &buf).into())
-    }
-}
-
-fn write_batch(mut buf: &mut Vec<u8>, batch: &RecordBatch) -> Result<(), ArrowError> {
-    let mut writer = StreamWriter::try_new(&mut buf, batch.schema().as_ref())?;
-    writer.write(batch)?;
-    writer.finish()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod utils;
 fn _raysql_internal(_py: Python, m: &PyModule) -> PyResult<()> {
     // register classes that can be created directly from Python code
     m.add_class::<context::PyContext>()?;
-    m.add_class::<context::PyResultSet>()?;
+    m.add_class::<planner::PyExecutionGraph>()?;
     m.add_class::<query_stage::PyQueryStage>()?;
     m.add_function(wrap_pyfunction!(execute_partition, m)?)?;
     m.add_function(wrap_pyfunction!(serialize_execution_plan, m)?)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,7 @@ extern crate core;
 use pyo3::prelude::*;
 
 mod proto;
-use crate::context::{
-    deserialize_execution_plan, empty_result_set, execute_partition, serialize_execution_plan,
-};
+use crate::context::{deserialize_execution_plan, execute_partition, serialize_execution_plan};
 pub use proto::generated::protobuf;
 
 pub mod context;
@@ -24,6 +22,5 @@ fn _raysql_internal(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(execute_partition, m)?)?;
     m.add_function(wrap_pyfunction!(serialize_execution_plan, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize_execution_plan, m)?)?;
-    m.add_function(wrap_pyfunction!(empty_result_set, m)?)?;
     Ok(())
 }

--- a/src/query_stage.rs
+++ b/src/query_stage.rs
@@ -81,7 +81,9 @@ impl QueryStage {
     /// Get the input partition count. This is the same as the number of concurrent tasks
     /// when we schedule this query stage for execution
     pub fn get_input_partition_count(&self) -> usize {
-        _get_output_partition_count(self.plan.children()[0].as_ref())
+        self.plan.children()[0]
+            .output_partitioning()
+            .partition_count()
     }
 
     pub fn get_output_partition_count(&self) -> usize {

--- a/src/shuffle/ray_shuffle/reader.rs
+++ b/src/shuffle/ray_shuffle/reader.rs
@@ -1,5 +1,4 @@
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::Statistics;
 use datafusion::error::DataFusionError;
@@ -14,7 +13,6 @@ use futures::Stream;
 use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Formatter;
-use std::io::Cursor;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
@@ -31,7 +29,7 @@ pub struct RayShuffleReaderExec {
     /// Output partitioning
     partitioning: Partitioning,
     /// Input streams from Ray object store
-    input_partitions_map: RwLock<HashMap<PartitionId, Vec<Vec<u8>>>>, // TODO(@lsf) can we not use Rwlock?
+    input_partitions_map: RwLock<HashMap<PartitionId, Vec<RecordBatch>>>, // TODO(@lsf) can we not use Rwlock?
 }
 
 impl RayShuffleReaderExec {
@@ -61,11 +59,11 @@ impl RayShuffleReaderExec {
     pub fn add_input_partition(
         &self,
         partition: PartitionId,
-        input_partition: Vec<u8>,
+        input_batch: RecordBatch,
     ) -> Result<(), DataFusionError> {
         let mut map = self.input_partitions_map.write().unwrap();
         let input_partitions = map.entry(partition).or_insert(vec![]);
-        input_partitions.push(input_partition);
+        input_partitions.push(input_batch);
         Ok(())
     }
 }
@@ -104,9 +102,8 @@ impl ExecutionPlan for RayShuffleReaderExec {
         partition: usize,
         _context: Arc<TaskContext>,
     ) -> datafusion::common::Result<SendableRecordBatchStream> {
-        let map = self.input_partitions_map.read().expect("got lock");
-        let empty_input_objects = vec![];
-        let input_objects = map.get(&partition).unwrap_or(&empty_input_objects);
+        let mut map = self.input_partitions_map.write().expect("got lock");
+        let input_objects = map.remove(&partition).unwrap_or(vec![]);
         println!(
             "RayShuffleReaderExec[stage={}].execute(input_partition={partition}) with {} shuffle inputs",
             self.stage_id,
@@ -114,7 +111,9 @@ impl ExecutionPlan for RayShuffleReaderExec {
         );
         let mut streams = vec![];
         for input in input_objects {
-            streams.push(Box::pin(InMemoryShuffleStream::try_new(input)?) as SendableRecordBatchStream);
+            streams.push(
+                Box::pin(InMemoryShuffleStream::try_new(input)?) as SendableRecordBatchStream
+            );
         }
         Ok(Box::pin(CombinedRecordBatchStream::new(
             self.schema.clone(),
@@ -136,13 +135,16 @@ impl ExecutionPlan for RayShuffleReaderExec {
 }
 
 struct InMemoryShuffleStream {
-    reader: StreamReader<Cursor<Vec<u8>>>,
+    batch: Arc<RecordBatch>,
+    read: bool,
 }
 
 impl InMemoryShuffleStream {
-    fn try_new(bytes: &Vec<u8>) -> Result<Self, DataFusionError> {
-        let reader = StreamReader::try_new(Cursor::new(bytes.clone()), None)?;
-        Ok(Self { reader })
+    fn try_new(batch: RecordBatch) -> Result<Self, DataFusionError> {
+        Ok(Self {
+            batch: Arc::new(batch),
+            read: false,
+        })
     }
 }
 
@@ -150,15 +152,17 @@ impl Stream for InMemoryShuffleStream {
     type Item = datafusion::error::Result<RecordBatch>;
 
     fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if let Some(batch) = self.reader.next() {
-            return Poll::Ready(Some(batch.map_err(|e| e.into())));
-        }
-        Poll::Ready(None)
+        Poll::Ready(if self.read {
+            None
+        } else {
+            self.read = true;
+            Some(Ok(self.batch.as_ref().clone()))
+        })
     }
 }
 
 impl RecordBatchStream for InMemoryShuffleStream {
     fn schema(&self) -> SchemaRef {
-        self.reader.schema()
+        self.batch.schema()
     }
 }

--- a/src/shuffle/ray_shuffle/writer.rs
+++ b/src/shuffle/ray_shuffle/writer.rs
@@ -119,11 +119,16 @@ impl ExecutionPlan for RayShuffleWriterExec {
                     while let Some(result) = stream.next().await {
                         writer.write(result?)?;
                     }
+                    println!(
+                        "RayShuffleWriterExec[stage={}] Finished writing shuffle partition 0. Batches: {}. Rows: {}. Bytes: {}.",
+                        stage_id,
+                        writer.num_batches,
+                        writer.num_rows,
+                        writer.num_bytes
+                    );
                     MemoryStream::try_new(vec![writer.finish()?], schema, None)
                 }
                 Partitioning::Hash(_, _) => {
-                    // TODO(@lsf) What happens if there are multiple RecordBatches
-                    // assigned to the same writer?
                     let mut writers: Vec<InMemoryWriter> = vec![];
                     for _ in 0..partition_count {
                         writers.push(InMemoryWriter::new(schema.clone()));
@@ -143,16 +148,14 @@ impl ExecutionPlan for RayShuffleWriterExec {
                     }
                     let mut result_batches = vec![];
                     for (i, w) in writers.iter_mut().enumerate() {
-                        if w.num_batches > 0 {
-                            debug!(
-                                "RayShuffleWriterExec[stage={}] Finished writing shuffle partition {}. Batches: {}. Rows: {}. Bytes: {}.",
-                                stage_id,
-                                i,
-                                w.num_batches,
-                                w.num_rows,
-                                w.num_bytes
-                            );
-                        }
+                        println!(
+                            "RayShuffleWriterExec[stage={}] Finished writing shuffle partition {}. Batches: {}. Rows: {}. Bytes: {}.",
+                            stage_id,
+                            i,
+                            w.num_batches,
+                            w.num_rows,
+                            w.num_bytes
+                        );
                         result_batches.push(w.finish()?);
                     }
                     debug!(
@@ -208,6 +211,8 @@ impl InMemoryWriter {
     }
 
     fn finish(&self) -> Result<RecordBatch> {
+        // TODO(@lsf) Instead of concatenating the batches, return all RecordBatches from
+        // all partitions in one stream, then return an array of batch offsets.
         concat_batches(&self.schema, &self.batches).map_err(DataFusionError::ArrowError)
     }
 }


### PR DESCRIPTION
Ray Shuffle is currently 2x slower than disk-based shuffle. My theory is that there is too much serde and memcpys going on. There really shouldn't be any because the Arrow in-memory format is supported natively by the Ray object store. This PR addresses that.

In this PR:
* Removed PyResultSet and PyRecordBatch. Instead, use the native `pyarrow.RecordBatch` and `pyarrow.ResultSet`. This makes them picklable so that we don't have to convert them from bytes.
* I realized `schedule_execution` really doesn't have to be remote tasks since with Ray shuffle we are scheduling all tasks at the beginning of execution. Hence made it a recursive function call. This also saves serde cost of execution plans.

Using PyArrow, Ray Shuffle is now slightly faster than disk-based shuffle on a single node. (See before/after comparison. Plot titles are wrong; this is on a single node).

![before](https://user-images.githubusercontent.com/2411818/229169382-3f507b7c-f8f4-4eef-8294-ade36387569d.png)
![after](https://user-images.githubusercontent.com/2411818/230214356-49d7b0c4-2336-4674-bb63-375d6ddc0c6e.png)

I also tested against SparkSQL on a 4-node cluster and RaySQL is 2.5x faster.

![4node](https://user-images.githubusercontent.com/2411818/230230178-70af301e-b44b-493b-83d0-e33b76d3c253.png)
